### PR TITLE
Update PDK cask handling of MacOS version

### DIFF
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -16,11 +16,10 @@ cask 'pdk' do
     }
   }
 
-  case MacOS.version
-  when :high_sierra
+  if MacOS.version == :high_sierra
     sha = version_map[:high_sierra][:sha]
     os_ver = version_map[:high_sierra][:ver]
-  when :sierra
+  elsif MacOS.version == :sierra
     sha = version_map[:sierra][:sha]
     os_ver = version_map[:sierra][:ver]
   else


### PR DESCRIPTION
Switching the MacOS version check from a case statement to a standard
if/else block because the MacOS.version is able to compare against
symbols or version string, which may be causing an issue as the subject
of a case statement.

For reference:
https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/readme.md