### PR TITLE
(maint) Update cask generation to support puppet-agent

### DIFF
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -1,22 +1,22 @@
 cask 'pdk' do
-  version '1.7.0.0'
-
-  case MacOS.version.to_sym
-  when :el_capitan
+  case MacOS.version
+  when '10.11'
+    version '1.7.0.0'
     sha256 '451fc9fda86bd8df0a1be72c6145f433828075e304750df125b47e4c30a3567e'
-  when :sierra
+  when '10.12'
+    version '1.7.0.0'
     sha256 'ae81c8fe3009d1e74fca4c81e8d635f86207dd8c40f2af057b7544c825e8b8b2'
-  when :high_sierra
+  when '10.13'
+    version '1.7.0.0'
     sha256 '484d8a317db2074d10c0c89818bbf712412e2bb493ae6464a6575990f114211b'
   end
 
+  depends_on macos: '>= 10.11'
   url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/pdk-#{version}-1.osx#{MacOS.version}.dmg"
+  pkg "pdk-#{version}-1-installer.pkg"
+
   name 'Puppet Development Kit'
   homepage 'https://github.com/puppetlabs/pdk'
-
-  depends_on macos: '>= 10.11'
-
-  pkg "pdk-#{version}-1-installer.pkg"
 
   uninstall pkgutil: 'com.puppetlabs.pdk'
 end

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -1,28 +1,25 @@
 cask 'puppet-agent' do
-  os_ver = MacOS.version.to_s
-  
-  if MacOS.version == :yosemite
-    version '5.5.0-1'
+  case MacOS.version
+  when '10.10'
+    version '5.5.0'
     sha256 '3f30c36e9b39763839148aaea400193c7b52d8feea2765121f6dabace658ec25'
-  elsif MacOS.version == :el_capitan
-    version '5.5.0-1'
+  when '10.11'
+    version '5.5.0'
     sha256 'fe60c24d2b964f161599bf4594c9e871f161707375b81c6b1e998e8cfce13058'
-  elsif MacOS.version == :sierra
-    version '5.5.4-1'
+  when '10.12'
+    version '5.5.4'
     sha256 '07ff138cd5c9c77fb0aa7822f21b5aa52314afebb18a25fca4efb8a86f9d604f'
-  else
-    version '5.5.4-1'
+  when '10.13'
+    version '5.5.4'
     sha256 '5138c22d4c2d75111b23d3a927a26e6a82d936cf2145dbd031e602799edcd1a8'
   end
-  
-  url "https://downloads.puppetlabs.com/mac/puppet/#{os_ver}/x86_64/puppet-agent-#{version}.osx#{os_ver}.dmg"
-  appcast "https://downloads.puppetlabs.com/mac/puppet/#{os_ver}/x86_64/"
+
+  depends_on macos: '>= 10.10'
+  url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  pkg "puppet-agent-#{version}-1-installer.pkg"
+
   name 'Puppet Agent'
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
-
-  depends_on macos: '>= :yosemite'
-
-  pkg "puppet-agent-#{version}-installer.pkg"
 
   uninstall launchctl: [
                          'puppet',

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -1,22 +1,22 @@
 cask 'puppet-bolt' do
-  version '0.21.6'
-
-  case MacOS.version.to_sym
-  when :el_capitan
+  case MacOS.version
+  when '10.11'
+    version '0.21.6'
     sha256 'ea2a4cfed3e2b5c35020788506fd195166083aeef0d9d45a8f3522c9cd129727'
-  when :sierra
+  when '10.12'
+    version '0.21.6'
     sha256 '20c9a2abc3ddfcbc8d94681222cad7814fe4881bff51d571e3ce256aecbdcb14'
-  when :high_sierra
+  when '10.13'
+    version '0.21.6'
     sha256 '7bd2f8e73b4526616cdc6f87fc355dc1cb2ae6a79075e86a2c83d08040b1b3f9'
   end
 
+  depends_on macos: '>= 10.11'
   url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/puppet-bolt-#{version}-1.osx#{MacOS.version}.dmg"
+  pkg "puppet-bolt-#{version}-1-installer.pkg"
+
   name 'Puppet Bolt'
   homepage 'https://github.com/puppetlabs/bolt'
-
-  depends_on macos: '>= 10.11'
-
-  pkg "puppet-bolt-#{version}-1-installer.pkg"
 
   uninstall pkgutil: 'com.puppetlabs.puppet-bolt'
 end

--- a/templates/pdk.rb.erb
+++ b/templates/pdk.rb.erb
@@ -1,20 +1,7 @@
 cask 'pdk' do
-  version '<%= latest_version %>'
-
-  case MacOS.version.to_sym
-<% os_versions.values.zip(shas).each do |name, sha| -%>
-  when :<%= name %>
-    sha256 '<%= sha %>'
-<% end -%>
-  end
-
-  url "<%= url %>"
+<%= source_stanza %>
   name 'Puppet Development Kit'
   homepage 'https://github.com/puppetlabs/pdk'
-
-  depends_on macos: '>= 10.11'
-
-  pkg "pdk-#{version}-1-installer.pkg"
 
   uninstall pkgutil: 'com.puppetlabs.pdk'
 end

--- a/templates/puppet-agent.rb.erb
+++ b/templates/puppet-agent.rb.erb
@@ -1,0 +1,17 @@
+cask 'puppet-agent' do
+<%= source_stanza %>
+  name 'Puppet Agent'
+  homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
+
+  uninstall launchctl: [
+                         'puppet',
+                         'pxp-agent',
+                         'mcollective',
+                       ],
+            pkgutil:   'com.puppetlabs.puppet-agent'
+
+  zap trash: [
+               '~/.puppetlabs',
+               '/etc/puppetlabs',
+             ]
+end

--- a/templates/puppet-bolt.rb.erb
+++ b/templates/puppet-bolt.rb.erb
@@ -1,20 +1,7 @@
 cask 'puppet-bolt' do
-  version '<%= latest_version %>'
-
-  case MacOS.version.to_sym
-<% os_versions.values.zip(shas).each do |name, sha| -%>
-  when :<%= name %>
-    sha256 '<%= sha %>'
-<% end -%>
-  end
-
-  url "<%= url %>"
+<%= source_stanza %>
   name 'Puppet Bolt'
   homepage 'https://github.com/puppetlabs/bolt'
-
-  depends_on macos: '>= 10.11'
-
-  pkg "puppet-bolt-#{version}-1-installer.pkg"
 
   uninstall pkgutil: 'com.puppetlabs.puppet-bolt'
 end

--- a/templates/source_stanza.erb
+++ b/templates/source_stanza.erb
@@ -1,0 +1,11 @@
+  case MacOS.version
+<% package_triples.each do |os_ver, pkg_ver, sha| -%>
+  when '<%= os_ver %>'
+    version '<%= pkg_ver %>'
+    sha256 '<%= sha %>'
+<% end -%>
+  end
+
+  depends_on macos: '>= <%= package_triples[0][0] %>'
+  url "<%= url %>"
+  pkg "<%= pkg %>-#{version}-1-installer.pkg"


### PR DESCRIPTION
Updates the Rake task to generate casks to support differing versions
for puppet-agent. Add a new puppet-agent template. Regenerate all casks.