### PR TITLE
Add support for multiple Puppet collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 os: osx
-# These represent OS X 10.10 - 10.13
+# These represent OS X 10.12 - 10.13.
+# Extra matrix entries add OS X 10.10 - 10.11.
 osx_image:
   - xcode10
   - xcode9.2
-  - xcode8
-  - xcode6.4
 env:
   matrix:
     - CASK=pdk
     - CASK=puppet-agent
+    - CASK=puppet-agent-5
+    - CASK=puppet-agent-6
     - CASK=puppet-bolt
 script:
   - brew cask install Casks/$CASK.rb --force
 matrix:
-  exclude:
-    - osx_image: xcode6.4
+  include:
+    - osx_image: xcode8
       env: CASK=pdk
     - osx_image: xcode6.4
+      env: CASK=puppet-agent-5
+    - osx_image: xcode8
+      env: CASK=puppet-agent-5
+    - osx_image: xcode8
       env: CASK=puppet-bolt

--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -1,18 +1,21 @@
 cask 'pdk' do
   case MacOS.version
   when '10.11'
+    os_ver = '10.11'
     version '1.7.0.0'
     sha256 '451fc9fda86bd8df0a1be72c6145f433828075e304750df125b47e4c30a3567e'
   when '10.12'
+    os_ver = '10.12'
     version '1.7.0.0'
     sha256 'ae81c8fe3009d1e74fca4c81e8d635f86207dd8c40f2af057b7544c825e8b8b2'
-  when '10.13'
+  else
+    os_ver = '10.13'
     version '1.7.0.0'
     sha256 '484d8a317db2074d10c0c89818bbf712412e2bb493ae6464a6575990f114211b'
   end
 
   depends_on macos: '>= 10.11'
-  url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/pdk-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 
   name 'Puppet Development Kit'

--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -1,21 +1,25 @@
 cask 'puppet-agent-5' do
   case MacOS.version
   when '10.10'
+    os_ver = '10.10'
     version '5.5.0'
     sha256 '3f30c36e9b39763839148aaea400193c7b52d8feea2765121f6dabace658ec25'
   when '10.11'
+    os_ver = '10.11'
     version '5.5.0'
     sha256 'fe60c24d2b964f161599bf4594c9e871f161707375b81c6b1e998e8cfce13058'
   when '10.12'
+    os_ver = '10.12'
     version '5.5.6'
     sha256 'd6e047acbcba21b8097d52c74292296b7cf1b3e0e951017eca4bf6bb411034cb'
-  when '10.13'
+  else
+    os_ver = '10.13'
     version '5.5.6'
     sha256 '3b43ab03a6376e52fe9a079c7ba07300585f8cf7ee4d7a76e825599755f493b5'
   end
 
   depends_on macos: '>= 10.10'
-  url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 
   name 'Puppet Agent'

--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -1,0 +1,35 @@
+cask 'puppet-agent-5' do
+  case MacOS.version
+  when '10.10'
+    version '5.5.0'
+    sha256 '3f30c36e9b39763839148aaea400193c7b52d8feea2765121f6dabace658ec25'
+  when '10.11'
+    version '5.5.0'
+    sha256 'fe60c24d2b964f161599bf4594c9e871f161707375b81c6b1e998e8cfce13058'
+  when '10.12'
+    version '5.5.6'
+    sha256 'd6e047acbcba21b8097d52c74292296b7cf1b3e0e951017eca4bf6bb411034cb'
+  when '10.13'
+    version '5.5.6'
+    sha256 '3b43ab03a6376e52fe9a079c7ba07300585f8cf7ee4d7a76e825599755f493b5'
+  end
+
+  depends_on macos: '>= 10.10'
+  url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  pkg "puppet-agent-#{version}-1-installer.pkg"
+
+  name 'Puppet Agent'
+  homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
+
+  uninstall launchctl: [
+                         'puppet',
+                         'pxp-agent',
+                         'mcollective',
+                       ],
+            pkgutil:   'com.puppetlabs.puppet-agent'
+
+  zap trash: [
+               '~/.puppetlabs',
+               '/etc/puppetlabs',
+             ]
+end

--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -1,4 +1,4 @@
-cask 'puppet-agent' do
+cask 'puppet-agent-6' do
   case MacOS.version
   when '10.12'
     version '6.0.2'
@@ -9,7 +9,7 @@ cask 'puppet-agent' do
   end
 
   depends_on macos: '>= 10.12'
-  url "https://downloads.puppet.com/mac/puppet/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet6/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 
   name 'Puppet Agent'

--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -1,15 +1,17 @@
 cask 'puppet-agent-6' do
   case MacOS.version
   when '10.12'
+    os_ver = '10.12'
     version '6.0.2'
     sha256 '5c76c20f321773f0d96bb6cf101606faa662a5f59d7ea6f766040ae4089ec7a2'
-  when '10.13'
+  else
+    os_ver = '10.13'
     version '6.0.2'
     sha256 '42b0af1c55089c2afcfc1fc64e6617cb3ebcd26d9ea19cf0aee78cb609eba99f'
   end
 
   depends_on macos: '>= 10.12'
-  url "https://downloads.puppet.com/mac/puppet6/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet6/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 
   name 'Puppet Agent'

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -1,15 +1,17 @@
 cask 'puppet-agent' do
   case MacOS.version
   when '10.12'
+    os_ver = '10.12'
     version '6.0.2'
     sha256 '5c76c20f321773f0d96bb6cf101606faa662a5f59d7ea6f766040ae4089ec7a2'
-  when '10.13'
+  else
+    os_ver = '10.13'
     version '6.0.2'
     sha256 '42b0af1c55089c2afcfc1fc64e6617cb3ebcd26d9ea19cf0aee78cb609eba99f'
   end
 
   depends_on macos: '>= 10.12'
-  url "https://downloads.puppet.com/mac/puppet/#{MacOS.version}/x86_64/puppet-agent-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 
   name 'Puppet Agent'

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -1,18 +1,21 @@
 cask 'puppet-bolt' do
   case MacOS.version
   when '10.11'
+    os_ver = '10.11'
     version '0.25.0'
     sha256 '46ec2baf382807ce787b2bb9fa778a90759c8c268d6ff3cb117fa12416cafbb1'
   when '10.12'
+    os_ver = '10.12'
     version '0.25.0'
     sha256 '0afa6ccc449086f514bdab010e4ce8c3db2ef97a243fbc4fcbde8e12be6befd6'
-  when '10.13'
+  else
+    os_ver = '10.13'
     version '0.25.0'
     sha256 'debbb942f2b3578a747c260811f6907c901ec520dbbaf10d94c2cbd57ff1aeb4'
   end
 
   depends_on macos: '>= 10.11'
-  url "https://downloads.puppet.com/mac/puppet5/#{MacOS.version}/x86_64/puppet-bolt-#{version}-1.osx#{MacOS.version}.dmg"
+  url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 
   name 'Puppet Bolt'

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ to learn more.
 
 ### Puppet Agent
 
-To install [Puppet Agent](https://github.com/puppetlabs/puppet-agent) with brew:
+To install the very latest [Puppet Agent](https://github.com/puppetlabs/puppet-agent) with brew:
 
 ```
 brew cask install puppetlabs/puppet/puppet-agent
 ```
+
+Additionally we maintain versioned casks for each collection
+- `puppetlabs/puppet/puppet-agent-5`
+- `puppetlabs/puppet/puppet-agent-6`
 
 ## Migrating from pre-tap installations
 
@@ -68,6 +72,11 @@ When new versions of packages are shipped, you can use a Rake task to update the
 
 ```
 rake 'brew:cask[puppet-bolt]'
+```
+
+To update the versioned casks - for example `puppet-agent-5` - include the collection as a 2nd argument
+```
+rake 'brew:cask[puppet-agent,5]'
 ```
 
 You can test updated Cask files with

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ namespace :brew do
       end.compact
     end
 
-    url = "https://#{host}#{path_pre}"+'#{MacOS.version}/x86_64/'+pkg+'-#{version}-1.osx#{MacOS.version}.dmg'
+    url = "https://#{host}#{path_pre}"+'#{os_ver}/x86_64/'+pkg+'-#{version}-1.osx#{os_ver}.dmg'
 
     source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), 0, '-').result(binding)
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,14 +14,26 @@ def fetch(http, req, limit = 10)
   end
 end
 
+PKG_TO_COLLECTIONS = {
+  'puppet-bolt' => 'puppet5',
+  'pdk' => 'puppet5'
+}
+
+def operating_systems(collection)
+  collection == 'puppet5' ? %w[10.10 10.11 10.12 10.13] : %w[10.11 10.12 10.13]
+end
+
 namespace :brew do
-  desc 'Update SHAs for a specific package: rake brew:cask[puppet-bolt]'
-  task :cask, [:pkg] do |task, args|
+  desc 'Update SHAs for a specific package: rake brew:cask[puppet-bolt] or rake brew:cask[puppet-agent,5]'
+  task :cask, [:pkg, :collection] do |task, args|
     pkg = args[:pkg]
-    os_versions = %w[10.10 10.11 10.12 10.13]
+    collection = PKG_TO_COLLECTIONS[pkg] || "puppet#{args[:collection]}"
+    cask = pkg
+    cask += '-' + args[:collection] if args[:collection]
+    os_versions = operating_systems(collection)
 
     host = 'downloads.puppet.com'
-    path_pre = '/mac/puppet5/'
+    path_pre = "/mac/#{collection}/"
     package_triples = Net::HTTP.start(host, use_ssl: true) do |http|
       latest_versions = os_versions.map do |os_ver|
         resp = fetch(http, "#{path_pre}#{os_ver}/x86_64")
@@ -43,8 +55,8 @@ namespace :brew do
 
     source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), 0, '-').result(binding)
 
-    cask = ERB.new(File.read(File.join(__dir__, 'templates', "#{pkg}.rb.erb")), 0, '-')
-    File.write(File.join(__dir__, 'Casks', "#{pkg}.rb"), cask.result(binding))
+    cask_erb = ERB.new(File.read(File.join(__dir__, 'templates', "#{cask}.rb.erb")), 0, '-')
+    File.write(File.join(__dir__, 'Casks', "#{cask}.rb"), cask_erb.result(binding))
   end
 end
 

--- a/templates/puppet-agent-5.rb.erb
+++ b/templates/puppet-agent-5.rb.erb
@@ -1,4 +1,4 @@
-cask 'puppet-agent' do
+cask 'puppet-agent-5' do
 <%= source_stanza %>
   name 'Puppet Agent'
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
@@ -6,6 +6,7 @@ cask 'puppet-agent' do
   uninstall launchctl: [
                          'puppet',
                          'pxp-agent',
+                         'mcollective',
                        ],
             pkgutil:   'com.puppetlabs.puppet-agent'
 

--- a/templates/puppet-agent-6.rb.erb
+++ b/templates/puppet-agent-6.rb.erb
@@ -1,4 +1,4 @@
-cask 'puppet-agent' do
+cask 'puppet-agent-6' do
 <%= source_stanza %>
   name 'Puppet Agent'
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"

--- a/templates/source_stanza.erb
+++ b/templates/source_stanza.erb
@@ -1,9 +1,14 @@
   case MacOS.version
-<% package_triples.each do |os_ver, pkg_ver, sha| -%>
+<% package_triples.take(package_triples.count-1).each do |os_ver, pkg_ver, sha| -%>
   when '<%= os_ver %>'
+    os_ver = '<%= os_ver %>'
     version '<%= pkg_ver %>'
     sha256 '<%= sha %>'
 <% end -%>
+  else
+    os_ver = '<%= package_triples.last[0] %>'
+    version '<%= package_triples.last[1] %>'
+    sha256 '<%= package_triples.last[2] %>'
   end
 
   depends_on macos: '>= <%= package_triples[0][0] %>'


### PR DESCRIPTION
Updates the `puppet-agent` cask to track the `puppet` collection, which
is an alias to the latest versioned collection. Adds `puppet-agent-5`
and `puppet-agent-6` casks tracking the `puppet5` and `puppet6`
collections.