### PR TITLE
(maint) travis-ci [2762] prevent homebrew regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ osx_image:
   - xcode10
   - xcode9.2
 env:
+  global:
+    - HOMEBREW_LOGS=~/homebrew-logs
+    - HOMEBREW_TEMP=~/homebrew-temp
   matrix:
     - CASK=pdk
     - CASK=puppet-agent


### PR DESCRIPTION
Homebrew regression: https://github.com/Homebrew/brew/issues/5513

Brew team has already released a fix for this, but it will take some time until it's officially released as a new version. Travis support is escalating this to macOS infrastructure team to see if there's a fix that they can apply manually, but in the meantime it appears that defining some brew env vars in .travis.yml configuration file will help workaround this brew issue.