### PR TITLE
Add a caveat about the paths for pdk and bolt

### DIFF
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -21,9 +21,11 @@ cask 'pdk' do
   name 'Puppet Development Kit'
   homepage 'https://github.com/puppetlabs/pdk'
 
-  caveats do
-    path_environment_variable '/opt/puppetlabs/pdk/bin'
-  end
+  pdk_bins = '/opt/puppetlabs/pdk/bin'
+  caveats %Q(
+    PDK binaries are installed in #{pdk_bins}, which is sourced by an /etc/paths.d entry.
+    #{pdk_bins} may not be included in your current $PATH but should be included in new shells.
+  )
 
   uninstall pkgutil: 'com.puppetlabs.pdk'
 end

--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -21,5 +21,9 @@ cask 'pdk' do
   name 'Puppet Development Kit'
   homepage 'https://github.com/puppetlabs/pdk'
 
+  caveats do
+    path_environment_variable '/opt/puppetlabs/pdk/bin'
+  end
+
   uninstall pkgutil: 'com.puppetlabs.pdk'
 end

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -21,9 +21,11 @@ cask 'puppet-bolt' do
   name 'Puppet Bolt'
   homepage 'https://github.com/puppetlabs/bolt'
 
-  caveats do
-    path_environment_variable '/opt/puppetlabs/bolt/bin'
-  end
+  bolt_bins = '/opt/puppetlabs/bolt/bin'
+  caveats %Q(
+    Puppet Bolt binaries are installed in #{bolt_bins}, which is sourced by an /etc/paths.d entry.
+    #{bolt_bins} may not be included in your current $PATH but should be included in new shells.
+  )
 
   uninstall pkgutil: 'com.puppetlabs.puppet-bolt'
 end

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -21,5 +21,9 @@ cask 'puppet-bolt' do
   name 'Puppet Bolt'
   homepage 'https://github.com/puppetlabs/bolt'
 
+  caveats do
+    path_environment_variable '/opt/puppetlabs/bolt/bin'
+  end
+
   uninstall pkgutil: 'com.puppetlabs.puppet-bolt'
 end


### PR DESCRIPTION
I tried installing `pdk` and `bolt` on MacOS and got confused about where exactly the binaries were. I ended up having to use `find` which was a not-so-great user experience.

This PR fixes that gripe by instructing the user to add `/opt/puppetlabs/pdk/bin` or `/opt/puppetlabs/bolt/bin` to their `$PATH` when installing `pdk` or `bolt`.

[Relevant brew cask reference doc](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/caveats.md).