### PR TITLE
(maint) Handle macOS 10.14 in rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ PKG_TO_COLLECTIONS = {
 }
 
 def operating_systems(collection)
-  collection == 'puppet5' ? %w[10.10 10.11 10.12 10.13] : %w[10.11 10.12 10.13]
+  collection == 'puppet5' ? %w[10.10 10.11 10.12 10.13 10.14] : %w[10.11 10.12 10.13 10.14]
 end
 
 namespace :brew do


### PR DESCRIPTION
Now that we are starting to ship builds for macOS mojave add 10.14 to the list of OS to check for when generating casks.