### PR TITLE
Changed collection to 'puppet' from 'puppet5'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,8 @@ def fetch(http, req, limit = 10)
 end
 
 PKG_TO_COLLECTIONS = {
-  'puppet-bolt' => 'puppet5',
-  'pdk' => 'puppet5'
+  'puppet-bolt' => 'puppet',
+  'pdk' => 'puppet'
 }
 
 def operating_systems(collection)


### PR DESCRIPTION
The 'puppet' collection is a rolling repo that tracks the latest versions of our software. This commit switches to it per a conversation with @mwaggett in Release Engineering.

I verified this would make the desired change by running the rake task locally and checking its diff to ensure that `puppet5` was replaced with `puppet`. Below is a diff of what would change if the task were run today. I am not including the run of the task as part of this PR since the versions of bolt and pdk have not yet changed.

```diff
diff --git a/Casks/pdk.rb b/Casks/pdk.rb
index c31ec45..9f84bc9 100644
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -3,23 +3,23 @@ cask 'pdk' do
   when '10.11'
     os_ver = '10.11'
     version '1.10.0.0'
-    sha256 '721005b6b2d367de6d7708d084db3a4dd607024fd112c33396a46c0be0f050e8'
+    sha256 'a4bd8dfa8fb4afe62b316020c081f40790679abee49e24458e2e7af967a41b24'
   when '10.12'
     os_ver = '10.12'
     version '1.10.0.0'
-    sha256 '92f7aa4b40aa25ef33db304cc024c093e01af945c4ac3e7d37603ee956ade5b8'
+    sha256 '4368a6ce59b271ee7eb3428d852950ecbee4862183539c6bfffb263b419f18f0'
   when '10.13'
     os_ver = '10.13'
     version '1.10.0.0'
-    sha256 '76bbdd4f09d566621d31da83bd4ff480f0b8a2fbeec0764e03ac7d7bf822f296'
+    sha256 'fb96b59f6a7de1f568f8e5da9ec60a2302c29947689411e99ff0bfc0c8b6bdbf'
   else
     os_ver = '10.14'
     version '1.10.0.0'
-    sha256 'f67b6eaf7ca0571fca2018c90621ab905c07aa582b59322b657ab4155f2ce940'
+    sha256 'c0d11afe9c8d1c9a9cf74d637055ce939d7a53d5674a68b0f51f7c9693720dab'
   end

   depends_on macos: '>= 10.11'
-  url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
+  url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"

   name 'Puppet Development Kit'
diff --git a/Casks/puppet-bolt.rb b/Casks/puppet-bolt.rb
index 2a6fc58..074dd4f 100644
--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -3,23 +3,23 @@ cask 'puppet-bolt' do
   when '10.11'
     os_ver = '10.11'
     version '1.16.0'
-    sha256 '65381f32528c5195562bd75a81a305c67f85d679f69134c44afae1eac2a52b9f'
+    sha256 'fa9c84ba2ba6c4d06d944eac205999940328384d393dec0deabfe15c3cd07bdb'
   when '10.12'
     os_ver = '10.12'
     version '1.16.0'
-    sha256 '998a63985bde41dc2e7c5286a678d5100b890548b539fc15e11d7bd4db16f543'
+    sha256 '0bc9b2a01210d0c4ee75621e7a182f83648f4701ebf1a0532988c4ebf9d4032f'
   when '10.13'
     os_ver = '10.13'
     version '1.16.0'
-    sha256 '5c9047267c432fd3a8454a22c2b226793cfe00d8f38cfb141b24ec36cfc49479'
+    sha256 '54f4804b9a69c524929b89e813861511892060f2ddcbf373f9eb618ae7d472a3'
   else
     os_ver = '10.14'
     version '1.16.0'
-    sha256 '344b00ee945c5f1ed5f0014bceb1d26aebda91969b67bc28c751e77c3906e9fa'
+    sha256 '4432713336dc0a95241939c0872e0bcd3971fd91a93f92ae2605281807fa2a13'
   end

   depends_on macos: '>= 10.11'
-  url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
+  url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"

   name 'Puppet Bolt'
```