### PR TITLE
Add homebrew formula for wash

### DIFF
--- a/Formula/wash.rb
+++ b/Formula/wash.rb
@@ -1,0 +1,19 @@
+class Wash < Formula
+  version = "0.1.0"
+  homepage "https://puppetlabs.github.io/wash"
+  url "https://github.com/puppetlabs/wash/archive/#{version}.tar.gz"
+  sha256 "aadc78ce7209c553c510b609b40c1fd6071360b9df7ba06449095b1f110b46de"
+
+  head "https://github.com/puppetlabs/wash.git"
+
+  depends_on "go" => [:build, "1.12.0"]
+
+  def install
+    system "go build -ldflags='-w -s -X github.com/puppetlabs/wash/cmd.version=#{version}'"
+    bin.install "wash" => "wash"
+  end
+
+  test do
+    system "#{bin}/wash", "help"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A tap for [Puppet](https://puppet.com) OSX packages
 brew cask install puppetlabs/puppet/<package>
 ```
 
+or
+
+```
+brew install puppetlabs/puppet/<package>
+```
+
 ### Bolt
 
 To install [Bolt](https://github.com/puppetlabs/bolt) with brew run
@@ -48,6 +54,16 @@ brew cask install puppetlabs/puppet/puppet-agent
 Additionally we maintain versioned casks for each collection
 - `puppetlabs/puppet/puppet-agent-5`
 - `puppetlabs/puppet/puppet-agent-6`
+
+### Wash
+
+To install [Wash](https://github.com/puppetlabs/wash) with brew:
+
+```
+brew install puppetlabs/puppet/wash
+```
+
+This will build Wash (with Go) and install it to `/usr/local/bin/wash`.
 
 ## Migrating from pre-tap installations
 


### PR DESCRIPTION
Adds a homebrew formula for building and installing wash from scratch. This is a young project, but I don't see any obvious reason to create a new tap for it.

Supports puppetlabs/wash#241.