### PR TITLE
Updating 'depends_on macos' lines for new formatting

### DIFF
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -18,7 +18,7 @@ cask 'pdk' do
     sha256 '23015cb190e70d4af40e226175db18f400a4f5ff9bf935d40d29aea4a72d5efb'
   end
 
-  depends_on macos: '>= 10.11'
+  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -22,7 +22,7 @@ cask 'puppet-agent-5' do
     sha256 'eb2e61fc7e403e670f595d677c635711f293cbdb0bf936e46d41d5f9d9dc0558'
   end
 
-  depends_on macos: '>= 10.10'
+  depends_on macos: '>= :yosemite'
   url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -14,7 +14,7 @@ cask 'puppet-agent-6' do
     sha256 '604fd125f501ad3dd1472e56fa5a76b4f490484f8be484dd779fe40349f38e77'
   end
 
-  depends_on macos: '>= 10.12'
+  depends_on macos: '>= :sierra'
   url "https://downloads.puppet.com/mac/puppet6/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -14,7 +14,7 @@ cask 'puppet-agent' do
     sha256 '604fd125f501ad3dd1472e56fa5a76b4f490484f8be484dd779fe40349f38e77'
   end
 
-  depends_on macos: '>= 10.12'
+  depends_on macos: '>= :sierra'
   url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -18,7 +18,7 @@ cask 'puppet-bolt' do
     sha256 '9f068f26389ca59f0b1ada7cf76e9688a7b9aec70a9ab78f3ce5428d1aa4f18f'
   end
 
-  depends_on macos: '>= 10.11'
+  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 


### PR DESCRIPTION
When running `brew cleanup`, I saw the following message:
Warning: Calling depends_on macos: "10.11" is deprecated and will be disabled on 2019-10-15! Use depends_on macos: :el_capitan instead.
Please report this to the puppetlabs/puppet tap, or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/puppetlabs/homebrew-puppet/Casks/pdk.rb:21

So here's the pull request to fix it.