### PR TITLE
Add codeowner's for the puppet-agent release

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 */wash.*        @puppetlabs/wash
 */puppet-bolt.* @puppetlabs/bolt
 */pdk.*         @puppetlabs/pdk
+*/puppet-agent* @puppetlabs/night-s-watch


### PR DESCRIPTION
Adds @puppetlabs/night-s-watch as codeowners for puppet-agent releases.

Signed-off-by: Michael Smith <michael.smith@puppet.com>