### PR TITLE
Add a recommended dependency on coreutils

### DIFF
--- a/Formula/wash.rb
+++ b/Formula/wash.rb
@@ -7,6 +7,8 @@ class Wash < Formula
   head "https://github.com/puppetlabs/wash.git"
 
   depends_on "go" => [:build, "1.12.0"]
+  option "with-coreutils", "Enables relative paths in the shell prompt using realpath"
+  depends_on "coreutils" => :recommended
 
   def install
     system "go build -ldflags='-w -s -X github.com/puppetlabs/wash/cmd/version.BuildVersion=#{version}'"


### PR DESCRIPTION
This installs `realpath`, which Wash uses to provide its shell prompt.
Coreutils will be installed by default, but use `recommended` to provide
the option to install without it because `coreutils` brings in several
applications that conflict with other packages. A future version of Wash
will include a fix for https://github.com/puppetlabs/wash/issues/492
that degrades gracefully if `realpath` is not present.

Signed-off-by: Michael Smith <michael.smith@puppet.com>