### PR TITLE
Correct service names for puppet-agent

### DIFF
--- a/templates/puppet-agent-5.rb.erb
+++ b/templates/puppet-agent-5.rb.erb
@@ -4,9 +4,9 @@ cask 'puppet-agent-5' do
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
 
   uninstall launchctl: [
-                         'puppet',
-                         'pxp-agent',
-                         'mcollective',
+                         'com.puppetlabs.puppet',
+                         'com.puppetlabs.pxp-agent',
+                         'com.puppetlabs.mcollective',
                        ],
             pkgutil:   'com.puppetlabs.puppet-agent'
 

--- a/templates/puppet-agent-6.rb.erb
+++ b/templates/puppet-agent-6.rb.erb
@@ -4,8 +4,8 @@ cask 'puppet-agent-6' do
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
 
   uninstall launchctl: [
-                         'puppet',
-                         'pxp-agent',
+                         'com.puppetlabs.puppet',
+                         'com.puppetlabs.pxp-agent',
                        ],
             pkgutil:   'com.puppetlabs.puppet-agent'
 

--- a/templates/puppet-agent.rb.erb
+++ b/templates/puppet-agent.rb.erb
@@ -4,8 +4,8 @@ cask 'puppet-agent' do
   homepage "https://puppet.com/docs/puppet/#{version.major_minor}/about_agent.html"
 
   uninstall launchctl: [
-                         'puppet',
-                         'pxp-agent',
+                         'com.puppetlabs.puppet',
+                         'com.puppetlabs.pxp-agent',
                        ],
             pkgutil:   'com.puppetlabs.puppet-agent'
 


### PR DESCRIPTION
Since at least the start of Puppet 5 the services have used a fully specified name - `com.puppetlabs.<service>` - instead of the simple service name. The original work on this cask didn't take that change into account. Update to use the correct service names so we uninstall them correctly.

Fixes #137.