### PR TITLE
Only build pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ osx_image:
   - xcode10.2
   - xcode10
   - xcode9.2
+branches:
+  only:
+    - master
 env:
   global:
     - HOMEBREW_LOGS=~/homebrew-logs


### PR DESCRIPTION
Disable building other branches so we only build pull requests and pushes to master. Prevents 'double builds' on Wash automated PRs.