### PR TITLE
Adds a Cask for PE Client Tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
     - HOMEBREW_TEMP=~/homebrew-temp
     - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
+    - CASK=pe-client-tools
+    - CASK=pe-client-tools-2019.3
+    - CASK=pe-client-tools-2018.1
     - CASK=pdk
     - CASK=puppet-agent
     - CASK=puppet-agent-5
@@ -23,6 +26,12 @@ script:
   - brew cask install Casks/$CASK.rb --force
 matrix:
   include:
+    - osx_image: xcode9.2
+      env: CASK=pe-client-tools
+    - osx_image: xcode10.1
+      env: CASK=pe-client-tools
+    - osx_image: xcode11.1
+      env: CASK=pe-client-tools
     - osx_image: xcode8
       env: CASK=pdk
     - osx_image: xcode6.4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
-*               @MikaelSmith
-*/wash.*        @puppetlabs/wash
-*/puppet-bolt.* @puppetlabs/bolt
-*/pdk.*         @puppetlabs/pdk
-*/puppet-agent* @puppetlabs/night-s-watch
+*                  @MikaelSmith
+*/wash.*           @puppetlabs/wash
+*/puppet-bolt.*    @puppetlabs/bolt
+*/pdk.*            @puppetlabs/pdk
+*/puppet-agent*    @puppetlabs/night-s-watch
+*/pe-client-tools* @puppetlabs/skeletor

--- a/Casks/pe-client-tools-2018.1.rb
+++ b/Casks/pe-client-tools-2018.1.rb
@@ -1,0 +1,21 @@
+cask 'pe-client-tools-2018.1' do
+  case MacOS.version
+  when '10.12'
+    os_ver = '10.12'
+    version '18.1.3'
+    sha256 '63c114696d1fb7642b493fb7111d922582cfb37e497cb0258e6d836a19af644a'
+  else
+    os_ver = '10.13'
+    version '18.1.3'
+    sha256 '9413d45d322bb96fbd3073055ce01022907a37659a0005242f64f2da2d34e08b'
+  end
+
+  depends_on macos: '>= :sierra'
+  url "https://pm.puppet.com/pe-client-tools/2018.1.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  pkg "pe-client-tools-#{version}-1-installer.pkg"
+
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/2018.1/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end

--- a/Casks/pe-client-tools-2019.3.rb
+++ b/Casks/pe-client-tools-2019.3.rb
@@ -1,0 +1,21 @@
+cask 'pe-client-tools-2019.3' do
+  case MacOS.version
+  when '10.12'
+    os_ver = '10.12'
+    version '19.3.0'
+    sha256 'd784e74325079ebecdbbc72ab5214c7f54be8ae1a38a6d4954bf52f7c02b1142'
+  else
+    os_ver = '10.13'
+    version '19.3.0'
+    sha256 'bccf0c588dd7d5e9dab92716e8471214c381e60f4f9246ba605091b253fb59f5'
+  end
+
+  depends_on macos: '>= :sierra'
+  url "https://pm.puppet.com/pe-client-tools/2019.3.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  pkg "pe-client-tools-#{version}-1-installer.pkg"
+
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/2019.3/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end

--- a/Casks/pe-client-tools.rb
+++ b/Casks/pe-client-tools.rb
@@ -1,0 +1,21 @@
+cask 'pe-client-tools' do
+  case MacOS.version
+  when '10.12'
+    os_ver = '10.12'
+    version '19.3.0'
+    sha256 'd784e74325079ebecdbbc72ab5214c7f54be8ae1a38a6d4954bf52f7c02b1142'
+  else
+    os_ver = '10.13'
+    version '19.3.0'
+    sha256 'bccf0c588dd7d5e9dab92716e8471214c381e60f4f9246ba605091b253fb59f5'
+  end
+
+  depends_on macos: '>= :sierra'
+  url "https://pm.puppet.com/pe-client-tools/2019.3.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  pkg "pe-client-tools-#{version}-1-installer.pkg"
+
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/latest/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # Homebrew Puppet
 
-A tap for [Puppet](https://puppet.com) OSX packages
+A tap for [Puppet](https://puppet.com) macOS packages
+
+- [How do I install these packages?](#how-do-i-install-these-packages)
+  - [Bolt](#bolt)
+  - [PE Client Tools](#pe-client-tools)
+  - [PDK](#pdk)
+  - [Puppet Agent](#puppet-agent)
+  - [Wash](#wash)
+- [Migrating from pre-tap installations](#migrating-from-pre-tap-installations)
+- [Updating versions](#updating-versions)
+  - [Updating pe-client-tools](#updating-pe-client-tools)
 
 ## How do I install these packages?
 
-```
+```bash
 brew cask install puppetlabs/puppet/<package>
 ```
 
 or
 
-```
+```bash
 brew install puppetlabs/puppet/<package>
 ```
 
@@ -18,21 +28,37 @@ brew install puppetlabs/puppet/<package>
 
 To install [Bolt](https://github.com/puppetlabs/bolt) with brew run
 
-```
+```bash
 brew cask install puppetlabs/puppet/puppet-bolt
 ```
 
 This will install bolt to `/opt/puppetlabs/bin/bolt`, so to use bolt add `/opt/puppetlabs/bin` to your path
 
-```
+```bash
 export PATH=$PATH:/opt/puppetlabs/bin
 ```
+
+### PE Client Tools
+
+To install the latest version of [PE Client Tools](https://puppet.com/docs/pe/latest/installing_pe_client_tools.html) run
+
+```bash
+brew cask isntall puppetlabs/puppet/pe-client-tools
+```
+
+To install the client tools for PE 2018.1, run
+
+```bash
+brew cask isntall puppetlabs/puppet/pe-client-tools-2018.1
+```
+
+This will install the stand-lone commands from pe-client-tools to `/opt/puppetlabs/bin` so you'll need to have `/opt/puppetlabs/bin` in your path. All the commands are also available via a puppet face if you have the puppet-agent installed too.
 
 ### PDK
 
 To install [PDK](https://github.com/puppetlabs/pdk) with brew:
 
-```
+```bash
 brew cask install puppetlabs/puppet/pdk
 ```
 
@@ -47,7 +73,7 @@ to learn more.
 
 To install the very latest [Puppet Agent](https://github.com/puppetlabs/puppet-agent) with brew:
 
-```
+```bash
 brew cask install puppetlabs/puppet/puppet-agent
 ```
 
@@ -59,7 +85,7 @@ Additionally we maintain versioned casks for each collection
 
 To install [Wash](https://github.com/puppetlabs/wash) with brew:
 
-```
+```bash
 brew install puppetlabs/puppet/wash
 ```
 
@@ -71,14 +97,14 @@ If you previously installed the PDK or Bolt from homebrew before this tap existe
 
 To remedy that, simply add the `puppetlabs/puppet` tap after updating homebrew:
 
-```
+```bash
 brew update
 brew tap puppetlabs/puppet
 ```
 
 After tapping, you can refer to the packages by their short name when interacting with them. For example:
 
-```
+```bash
 brew cask upgrade pdk
 ```
 
@@ -86,16 +112,33 @@ brew cask upgrade pdk
 
 When new versions of packages are shipped, you can use a Rake task to update the Cask to the latest version and SHAs
 
-```
+```bash
 rake 'brew:cask[puppet-bolt]'
 ```
 
 To update the versioned casks - for example `puppet-agent-5` - include the collection as a 2nd argument
-```
+
+```bash
 rake 'brew:cask[puppet-agent,5]'
 ```
 
 You can test updated Cask files with
-```
+
+```bash
 brew cask install Casks/puppet-bolt.rb --force
+```
+
+### Updating pe-client-tools
+
+Right now, pe-client-tools live in a location that can't be browsed so we needed a different rake task for it. There is a variable for the latest / default version of PE and a hash that defines the pe-client-tools version associated with each PE version.
+
+To pull down a new version of the client tools you will first want to update the variables in the Rakefile and then run one of these commands:
+
+```bash
+# utilize the LATEST_PE variable
+rake brew:pe_client_tools
+
+# Update the individual PE collections
+rake 'brew:pe_client_tools[2019.3]'
+rake 'brew:pe_client_tools[2018.1]'
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,17 @@ require 'erb'
 require 'net/http'
 require 'tmpdir'
 
-def fetch(http, req, limit = 10)
+def fetch(uri, limit = 10)
+  # puts "Fetching #{uri}" # Uncomment to debug what UR:'s are being fetched
   raise 'too many HTTP redirects' if limit == 0
-  resp = http.get(req)
-
-  case resp
-  when Net::HTTPSuccess then resp
-  when Net::HTTPRedirection then fetch(http, resp['location'], limit - 1)
-  else raise "Request for listing failed: #{resp.body}"
+  response = Net::HTTP.get_response(URI(uri))
+  case response
+  when Net::HTTPSuccess then
+    response
+  when Net::HTTPRedirection then
+    fetch(response['location'], limit - 1)
+  else
+    raise "Request for listing failed: #{response.body}"
   end
 end
 
@@ -28,8 +31,24 @@ VERSION_TO_CODENAME = {
   '10.15' => :catalina,
 }
 
+LATEST_PE = '2019.3'
+
+CLIENT_TOOLS = {
+  '2019.3' => '19.3.0',
+  '2018.1' => '18.1.3',
+}
+
 def operating_systems(collection)
-  collection == 'puppet5' ? %w[10.10 10.11 10.12 10.13 10.14] : %w[10.11 10.12 10.13 10.14]
+  case collection
+  when 'pct2019.3'
+    %w[10.12 10.13]
+  when 'pct2018.1'
+    %w[10.12 10.13]
+  when 'puppet5'
+    %w[10.10 10.11 10.12 10.13 10.14]
+  else
+    %w[10.11 10.12 10.13 10.14]
+  end
 end
 
 namespace :brew do
@@ -41,28 +60,58 @@ namespace :brew do
     cask += '-' + args[:collection] if args[:collection]
     os_versions = operating_systems(collection)
 
-    host = 'downloads.puppet.com'
-    path_pre = "/mac/#{collection}/"
-    package_triples = Net::HTTP.start(host, use_ssl: true) do |http|
-      latest_versions = os_versions.map do |os_ver|
-        resp = fetch(http, "#{path_pre}#{os_ver}/x86_64")
-        raise "Request for listing failed: #{resp.body}" unless resp.kind_of? Net::HTTPSuccess
-        versions = resp.body.scan(/#{pkg}-(\d+\.\d+\.\d+(?:\.\d+)?)-\d\.osx#{os_ver}\.dmg/).map(&:first).uniq
-        versions.sort_by! {|version| Gem::Version.new(version)}
-        versions.last
-      end
-      puts "Getting SHA256 sums for #{pkg}: #{latest_versions}"
+    path_pre = "https://downloads.puppet.com/mac/#{collection}/"
 
-      os_versions.zip(latest_versions).map do |os_ver, pkg_ver|
-        if pkg_ver
-          resp = http.get("#{path_pre}#{os_ver}/x86_64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
-          sha = Digest::SHA256.hexdigest(resp.body)
-          [os_ver, pkg_ver, sha]
-        end
-      end.compact
+    latest_versions = os_versions.map do |os_ver|
+      resp = fetch("#{path_pre}#{os_ver}/x86_64/")
+      raise "Request for listing failed: #{resp.body}" unless resp.kind_of? Net::HTTPSuccess
+      versions = resp.body.scan(/#{pkg}-(\d+\.\d+\.\d+(?:\.\d+)?)-\d\.osx#{os_ver}\.dmg/).map(&:first).uniq
+      versions.sort_by! {|version| Gem::Version.new(version)}
+      versions.last
+    end
+    puts "Getting SHA256 sums for #{pkg}: #{latest_versions}"
+
+    package_triples = os_versions.zip(latest_versions).map do |os_ver, pkg_ver|
+      if pkg_ver
+        resp = fetch("#{path_pre}#{os_ver}/x86_64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
+        sha = Digest::SHA256.hexdigest(resp.body)
+        [os_ver, pkg_ver, sha]
+      end
+    end.compact
+
+    url = "#{path_pre}"+'#{os_ver}/x86_64/'+pkg+'-#{version}-1.osx#{os_ver}.dmg'
+
+    source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), 0, '-').result(binding)
+
+    cask_erb = ERB.new(File.read(File.join(__dir__, 'templates', "#{cask}.rb.erb")), 0, '-')
+    File.write(File.join(__dir__, 'Casks', "#{cask}.rb"), cask_erb.result(binding))
+  end
+
+  desc 'Update SHAs for pe-client-tools: rake brew:pe_client_tools rake brew:pe_client_tools[2019.3]'
+  task :pe_client_tools, [:collection] do |task, args|
+    pkg = 'pe-client-tools'
+    collection = args[:collection] || LATEST_PE
+    version = CLIENT_TOOLS[collection]
+    cask = pkg
+    cask += '-' + args[:collection] if args[:collection]
+    os_versions = operating_systems("pct#{collection}")
+
+    path_pre = "https://pm.puppet.com/pe-client-tools/#{collection}.0/"
+
+    latest_versions = os_versions.map do |os_ver|
+      version
     end
 
-    url = "https://#{host}#{path_pre}"+'#{os_ver}/x86_64/'+pkg+'-#{version}-1.osx#{os_ver}.dmg'
+    package_triples = os_versions.zip(latest_versions).map do |os_ver, pkg_ver|
+      if pkg_ver
+        puts "Getting SHA256 sum for #{pkg} #{pkg_ver} on macOS #{os_ver}"
+        resp = fetch("#{path_pre}#{pkg_ver}/repos/apple/#{os_ver}/PC1/x86_64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
+        sha = Digest::SHA256.hexdigest(resp.body)
+        [os_ver, pkg_ver, sha]
+      end
+    end.compact
+
+    url = "#{path_pre}"+'#{version}/repos/apple/#{os_ver}/PC1/x86_64/'+pkg+'-#{version}-1.osx#{os_ver}.dmg'
 
     source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), 0, '-').result(binding)
 
@@ -70,4 +119,3 @@ namespace :brew do
     File.write(File.join(__dir__, 'Casks', "#{cask}.rb"), cask_erb.result(binding))
   end
 end
-

--- a/templates/pe-client-tools-2018.1.rb.erb
+++ b/templates/pe-client-tools-2018.1.rb.erb
@@ -1,0 +1,7 @@
+cask 'pe-client-tools-2018.1' do
+<%= source_stanza %>
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/2018.1/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end

--- a/templates/pe-client-tools-2019.3.rb.erb
+++ b/templates/pe-client-tools-2019.3.rb.erb
@@ -1,0 +1,7 @@
+cask 'pe-client-tools-2019.3' do
+<%= source_stanza %>
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/2019.3/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end

--- a/templates/pe-client-tools.rb.erb
+++ b/templates/pe-client-tools.rb.erb
@@ -1,0 +1,7 @@
+cask 'pe-client-tools' do
+<%= source_stanza %>
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/latest/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end


### PR DESCRIPTION
This commit also includes the following related changes:
- updates the CODEOWNERS file to indicate that the Skeletor owns
  pe-client-tools
- Also added cells in Travis CI for macOS 10.12, 10.13, & 10.14
- Refactors fetching url's to resolve an error discoved while trying to
  download from s3

Fixes #70