### PR TITLE
(PA-3123) Update Homebrew Puppet (Puppet Agent 6.13.0)

### DIFF
--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -2,16 +2,20 @@ cask 'puppet-agent-6' do
   case MacOS.version
   when '10.12'
     os_ver = '10.12'
-    version '6.12.0'
-    sha256 'b9d6c9a9481c0fa90c7a40624b9a60763e5fd88abf0b6800e5af1d5e3b46ca3e'
+    version '6.13.0'
+    sha256 '3577c3656b40014a97a409423db6b70dca80accab550b7966ecc0dd5c4fa9007'
   when '10.13'
     os_ver = '10.13'
-    version '6.12.0'
-    sha256 'b8264213ba37295193691402eb2fcd21060c4124b81e8756204145bd4f20b5e5'
-  else
+    version '6.13.0'
+    sha256 '2e4f6a316b633200fd2a9c0a0b57e3dea785c9f9c19e07ad4e295cdd00914b10'
+  when '10.14'
     os_ver = '10.14'
-    version '6.12.0'
-    sha256 '9d04991ca456c584c4fcf4255a575812a6a6dc2add390a451ac848580d9e0b70'
+    version '6.13.0'
+    sha256 '82dcdc799118f043c698ea32647ecee7c07163a47c5ce8417508ca6288531508'
+  else
+    os_ver = '10.15'
+    version '6.13.0'
+    sha256 '1b9091eda027f0ca78aa9660a22bb923e8783847ce3f6decaaa82c2e883d7a6e'
   end
 
   depends_on macos: '>= :sierra'

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -2,16 +2,20 @@ cask 'puppet-agent' do
   case MacOS.version
   when '10.12'
     os_ver = '10.12'
-    version '6.12.0'
-    sha256 'b9d6c9a9481c0fa90c7a40624b9a60763e5fd88abf0b6800e5af1d5e3b46ca3e'
+    version '6.13.0'
+    sha256 '3577c3656b40014a97a409423db6b70dca80accab550b7966ecc0dd5c4fa9007'
   when '10.13'
     os_ver = '10.13'
-    version '6.12.0'
-    sha256 'b8264213ba37295193691402eb2fcd21060c4124b81e8756204145bd4f20b5e5'
-  else
+    version '6.13.0'
+    sha256 '2e4f6a316b633200fd2a9c0a0b57e3dea785c9f9c19e07ad4e295cdd00914b10'
+  when '10.14'
     os_ver = '10.14'
-    version '6.12.0'
-    sha256 '9d04991ca456c584c4fcf4255a575812a6a6dc2add390a451ac848580d9e0b70'
+    version '6.13.0'
+    sha256 '82dcdc799118f043c698ea32647ecee7c07163a47c5ce8417508ca6288531508'
+  else
+    os_ver = '10.15'
+    version '6.13.0'
+    sha256 '1b9091eda027f0ca78aa9660a22bb923e8783847ce3f6decaaa82c2e883d7a6e'
   end
 
   depends_on macos: '>= :sierra'

--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ def operating_systems(collection)
   when 'puppet5'
     %w[10.10 10.11 10.12 10.13 10.14]
   else
-    %w[10.11 10.12 10.13 10.14]
+    %w[10.11 10.12 10.13 10.14 10.15]
   end
 end
 


### PR DESCRIPTION
Adding MacOSX 10.15 Catalina with Puppet Agent 6.13.0 release.