### PR TITLE
Add a homebrew formula for the relay.sh CLI

### DIFF
--- a/Formula/relay.rb
+++ b/Formula/relay.rb
@@ -1,0 +1,16 @@
+class Relay < Formula
+  version "v3.4.0"
+  homepage "https://relay.sh/"
+  url "https://github.com/puppetlabs/relay/releases/download/#{version}/nebula-#{version}-darwin-amd64", 
+    :using => :nounzip
+  sha256 "2b43e3deb12c6ad2449abcb85ca095cbefd8d6c35c98b3987986d43c7b375916"
+
+  def install
+    bin.install "nebula-#{version}-darwin-amd64" => "relay"
+  end
+
+  test do
+    system "#{bin}/relay", "help"
+  end
+
+end

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A tap for [Puppet](https://puppet.com) macOS packages
   - [PDK](#pdk)
   - [Puppet Agent](#puppet-agent)
   - [Wash](#wash)
+  - [Relay](#relay)
 - [Migrating from pre-tap installations](#migrating-from-pre-tap-installations)
 - [Updating versions](#updating-versions)
   - [Updating pe-client-tools](#updating-pe-client-tools)
@@ -90,6 +91,17 @@ brew install puppetlabs/puppet/wash
 ```
 
 This will build Wash (with Go) and install it to `/usr/local/bin/wash`.
+
+### Relay
+
+To install the CLI tool to interact with [Relay](https://relay.sh):
+
+```bash
+brew install puppetlabs/puppet/relay
+```
+
+This will install the relay CLI from the binary builds produced at 
+[@puppetlabs/relay](https://github.com/puppetlabs/relay) - no local build tools are required.
 
 ## Migrating from pre-tap installations
 


### PR DESCRIPTION
Currently this is built as `nebula` but until that changes
over we'll just install it as `relay`.