### PR TITLE
upgraded puppet-agent-6 cask to 6.19.1 for macos 10.14 and 10.15

### DIFF
--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -10,11 +10,11 @@ cask 'puppet-agent-6' do
     sha256 '2e4f6a316b633200fd2a9c0a0b57e3dea785c9f9c19e07ad4e295cdd00914b10'
   when '10.14'
     os_ver = '10.14'
-    version '6.16.0'
+    version '6.19.1'
     sha256 'f986aacbfe4528e9eaaefd33db8f785a62b6c8822668feee4245e2ab5b9c6730'
   else
     os_ver = '10.15'
-    version '6.16.0'
+    version '6.19.1'
     sha256 '9a890da6ef69b92cfd744548bdd81ac02b0bdb14eb57708eea0b8bf64aed18d2'
   end
 


### PR DESCRIPTION
cask reflects latest puppet6 releases now