### PR TITLE
(maint) remove OS X 10.12/10.13 from agent matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,7 @@ matrix:
       env: CASK=puppet-agent-7
     - osx_image: xcode10
       env: CASK=puppet-agent-7
+    - osx_image: xcode9.2
+      env: CASK=puppet-agent
+    - osx_image: xcode10
+      env: CASK=puppet-agent


### PR DESCRIPTION
puppet-agent formula was updated to puppet 7.
Update the travis matrix to remove the checks on
OS X 10.12/10.13 for puppet-agent 7.