### PR TITLE
Add puppet-bolt@2 Cask for users who aren't ready to upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - CASK=puppet-agent-6
     - CASK=puppet-agent-7
     - CASK=puppet-bolt
+    - CASK=puppet-bolt@2
 script:
   - brew cask install Casks/$CASK.rb --force
 matrix:
@@ -42,6 +43,8 @@ matrix:
       env: CASK=puppet-agent-5
     - osx_image: xcode8
       env: CASK=puppet-bolt
+    - osx_image: xcode8
+      env: CASK=puppet-bolt@2
     - osx_image: xcode10.2
       env: FORMULA=wash
       script: brew install Formula/$FORMULA.rb

--- a/Casks/puppet-bolt@2.rb
+++ b/Casks/puppet-bolt@2.rb
@@ -1,0 +1,39 @@
+cask 'puppet-bolt@2' do
+  case MacOS.version
+  when '10.11'
+    os_ver = '10.11'
+    version '2.0.0'
+    sha256 'a5956c7d075a6219f04cda8890732bb8e31b4e10ad0096e18046531b43cfdd7d'
+  when '10.12'
+    os_ver = '10.12'
+    version '2.0.0'
+    sha256 '9d14f5106bb1c882971658ca00537fd1f1e176685f31588637eab8b95feba0d7'
+  when '10.13'
+    os_ver = '10.13'
+    version '2.0.0'
+    sha256 'ec644414592e24f685e41f696e9830958b5c2223b7d489038529520faf3d3352'
+  when '10.14'
+    os_ver = '10.14'
+    version '2.44.0'
+    sha256 '6085ebc9f916b4ab83e6829d8e9e88860b96b9201ef459d750762ee732aba7b3'
+  else
+    os_ver = '10.15'
+    version '2.44.0'
+    sha256 'd8c4cbd2c2d6c4a0d8cb58007de2a7520939c51cabe8845d6d96013062d7e466'
+  end
+
+  depends_on macos: '>= :el_capitan'
+  url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
+  pkg "puppet-bolt-#{version}-1-installer.pkg"
+
+  name 'Puppet Bolt'
+  homepage 'https://github.com/puppetlabs/bolt'
+
+  bolt_bins = '/opt/puppetlabs/bolt/bin'
+  caveats %Q(
+    Puppet Bolt binaries are installed in #{bolt_bins}, which is sourced by an /etc/paths.d entry.
+    #{bolt_bins} may not be included in your current $PATH but should be included in new shells.
+  )
+
+  uninstall pkgutil: 'com.puppetlabs.puppet-bolt'
+end

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ This will install bolt to `/opt/puppetlabs/bin/bolt`, so to use bolt add `/opt/p
 export PATH=$PATH:/opt/puppetlabs/bin
 ```
 
+#### Installing Bolt 2.x
+
+To install Bolt 2.x, run
+
+```bash
+brew install puppetlabs/puppet/puppet-bolt@2
+```
+
 ### PE Client Tools
 
 To install the latest version of [PE Client Tools](https://puppet.com/docs/pe/latest/installing_pe_client_tools.html) run


### PR DESCRIPTION
We're planning to release Bolt 3.0 shortly. With most package managers
users can specify an older Bolt version if they aren't ready to upgrade,
but with homebrew we need to provide a separate puppet-bolt@2 package
for users who aren't ready to join the 3.x stream. This stream should
never be updated, it just exists so that homebrew users can easily
install Bolt 2.x.