### PR TITLE
PE Client Tools updates and travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 os: osx
-# These represent OS X 10.12 - 10.15.
-# Extra matrix entries add OS X 10.10 - 10.11.
+# These represent OS X 10.14 - 11.3.
 osx_image:
+  - xcode12.5 # 11.3
   - xcode12.2 # 10.15
   - xcode10.2 # 10.14
-  - xcode10 # 10.13
-  - xcode9.2 # 10.12
 branches:
   only:
     - master
@@ -17,11 +15,8 @@ env:
   matrix:
     - CASK=pe-client-tools
     - CASK=pe-client-tools-2019.8
-    - CASK=pe-client-tools-2019.3
-    - CASK=pe-client-tools-2018.1
     - CASK=pdk
     - CASK=puppet-agent
-    - CASK=puppet-agent-5
     - CASK=puppet-agent-6
     - CASK=puppet-agent-7
     - CASK=puppet-bolt
@@ -33,34 +28,9 @@ script:
   - brew install --cask Casks/$CASK.rb --force
 matrix:
   include:
-    - osx_image: xcode9.2
-      env: CASK=pe-client-tools-2019.3
-    - osx_image: xcode10.1
-      env: CASK=pe-client-tools
-    - osx_image: xcode11.1
-      env: CASK=pe-client-tools
-    - osx_image: xcode8
-      env: CASK=pdk
-    - osx_image: xcode6.4
-      env: CASK=puppet-agent-5
-    - osx_image: xcode8
-      env: CASK=puppet-agent-5
-    - osx_image: xcode8
-      env: CASK=puppet-bolt
-    - osx_image: xcode8
-      env: CASK=puppet-bolt@2
     - osx_image: xcode10.2
       env: FORMULA=wash
       script: brew install Formula/$FORMULA.rb
     - osx_image: xcode10.2
       env: FORMULA=relay
       script: brew install Formula/$FORMULA.rb
-  exclude:
-    - osx_image: xcode9.2
-      env: CASK=puppet-agent-7
-    - osx_image: xcode10
-      env: CASK=puppet-agent-7
-    - osx_image: xcode9.2
-      env: CASK=puppet-agent
-    - osx_image: xcode10
-      env: CASK=puppet-agent

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
     - CASK=pe-client-tools
+    - CASK=pe-client-tools-2019.8
     - CASK=pe-client-tools-2019.3
     - CASK=pe-client-tools-2018.1
     - CASK=pdk
@@ -25,12 +26,15 @@ env:
     - CASK=puppet-agent-7
     - CASK=puppet-bolt
     - CASK=puppet-bolt@2
+addons:
+  homebrew:
+    update: true
 script:
-  - brew cask install Casks/$CASK.rb --force
+  - brew install --cask Casks/$CASK.rb --force
 matrix:
   include:
     - osx_image: xcode9.2
-      env: CASK=pe-client-tools
+      env: CASK=pe-client-tools-2019.3
     - osx_image: xcode10.1
       env: CASK=pe-client-tools
     - osx_image: xcode11.1

--- a/Casks/pe-client-tools-2018.1.rb
+++ b/Casks/pe-client-tools-2018.1.rb
@@ -2,12 +2,12 @@ cask 'pe-client-tools-2018.1' do
   case MacOS.version
   when '10.12'
     os_ver = '10.12'
-    version '18.1.3'
-    sha256 '63c114696d1fb7642b493fb7111d922582cfb37e497cb0258e6d836a19af644a'
+    version '18.1.8'
+    sha256 'dab4d62b803bc322ce07c66820f443e1f85a967f77b752cf55262a500c1dce1a'
   else
     os_ver = '10.13'
-    version '18.1.3'
-    sha256 '9413d45d322bb96fbd3073055ce01022907a37659a0005242f64f2da2d34e08b'
+    version '18.1.8'
+    sha256 '327891491b80567b2af035de53422f81e010e727373f055f13626eb10c9c4553'
   end
 
   depends_on macos: '>= :sierra'

--- a/Casks/pe-client-tools-2019.8.rb
+++ b/Casks/pe-client-tools-2019.8.rb
@@ -1,20 +1,16 @@
 cask 'pe-client-tools-2019.8' do
   case MacOS.version
-  when '10.13'
-    os_ver = '10.13'
-    version '19.8.4'
-    sha256 '2c47f8ef4789d1cdf52d4b9d1e9d8e333101286117ab27bf6b9659929a7776fa'
   when '10.14'
     os_ver = '10.14'
-    version '19.8.4'
-    sha256 '1256319f55863af4ca8afb0eb3939e247a18104f5a0fd4cd4b59146487d99ca1'
+    version '19.8.5'
+    sha256 'dd4aa20af10f27f2c5fe58a8ca512dead51eb7bfa00b186d301c67135b108692'
   else
     os_ver = '10.15'
-    version '19.8.4'
-    sha256 '41b83875ff013d3e6dc91f59b49708d4076666e619d010c7cbce4f5412d0e3fa'
+    version '19.8.5'
+    sha256 '5be345ca3691f00b97c54f3cd5e523260257cb1e0589733dc1694b6241e5a7bb'
   end
 
-  depends_on macos: '>= :high_sierra'
+  depends_on macos: '>= :mojave'
   url "https://pm.puppet.com/pe-client-tools/2019.8.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 

--- a/Casks/pe-client-tools-2019.8.rb
+++ b/Casks/pe-client-tools-2019.8.rb
@@ -2,16 +2,16 @@ cask 'pe-client-tools-2019.8' do
   case MacOS.version
   when '10.14'
     os_ver = '10.14'
-    version '19.8.5'
-    sha256 'dd4aa20af10f27f2c5fe58a8ca512dead51eb7bfa00b186d301c67135b108692'
+    version '19.8.6'
+    sha256 'ce9c2db02c9fbb6b1cbf6ba9be4a2c569aa485a563350718a4435dc2a8185f3d'
   else
     os_ver = '10.15'
-    version '19.8.5'
-    sha256 '5be345ca3691f00b97c54f3cd5e523260257cb1e0589733dc1694b6241e5a7bb'
+    version '19.8.6'
+    sha256 '3cb72c8ac071b46b8b60a40a2018b44346205b386a1ee07e2006cd66ce98e3cb'
   end
 
   depends_on macos: '>= :mojave'
-  url "https://pm.puppet.com/pe-client-tools/2019.8.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  url "https://pm.puppet.com/pe-client-tools/2019.8.6/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 
   name 'PE Client Tools'

--- a/Casks/pe-client-tools-2019.8.rb
+++ b/Casks/pe-client-tools-2019.8.rb
@@ -1,4 +1,4 @@
-cask 'pe-client-tools' do
+cask 'pe-client-tools-2019.8' do
   case MacOS.version
   when '10.13'
     os_ver = '10.13'
@@ -19,7 +19,7 @@ cask 'pe-client-tools' do
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 
   name 'PE Client Tools'
-  homepage "https://puppet.com/docs/pe/latest/installing_pe_client_tools.html"
+  homepage "https://puppet.com/docs/pe/2019.8/installing_pe_client_tools.html"
 
   uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
 end

--- a/Casks/pe-client-tools.rb
+++ b/Casks/pe-client-tools.rb
@@ -1,21 +1,17 @@
 cask 'pe-client-tools' do
   case MacOS.version
-  when '10.13'
-    os_ver = '10.13'
-    version '19.8.4'
-    sha256 '2c47f8ef4789d1cdf52d4b9d1e9d8e333101286117ab27bf6b9659929a7776fa'
   when '10.14'
     os_ver = '10.14'
-    version '19.8.4'
-    sha256 '1256319f55863af4ca8afb0eb3939e247a18104f5a0fd4cd4b59146487d99ca1'
+    version '21.0.0'
+    sha256 'ca433c154a329c5fb57d46459f7086974bfe9d9b1966b9961a44ac739b7d09d9'
   else
     os_ver = '10.15'
-    version '19.8.4'
-    sha256 '41b83875ff013d3e6dc91f59b49708d4076666e619d010c7cbce4f5412d0e3fa'
+    version '21.0.0'
+    sha256 '4c0b9bcb5a14159e93b82e02bc27c6f3ce80291f3b74fb0ce50f2dbf1727d7d4'
   end
 
-  depends_on macos: '>= :high_sierra'
-  url "https://pm.puppet.com/pe-client-tools/2019.8.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  depends_on macos: '>= :mojave'
+  url "https://pm.puppet.com/pe-client-tools/2021.0.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 
   name 'PE Client Tools'

--- a/Casks/pe-client-tools.rb
+++ b/Casks/pe-client-tools.rb
@@ -2,16 +2,16 @@ cask 'pe-client-tools' do
   case MacOS.version
   when '10.14'
     os_ver = '10.14'
-    version '21.0.0'
-    sha256 'ca433c154a329c5fb57d46459f7086974bfe9d9b1966b9961a44ac739b7d09d9'
+    version '21.1.0'
+    sha256 'b8a808800091e481cf5b779d795203c84f8caabdaf8608ad6d7af23c136aa30e'
   else
     os_ver = '10.15'
-    version '21.0.0'
-    sha256 '4c0b9bcb5a14159e93b82e02bc27c6f3ce80291f3b74fb0ce50f2dbf1727d7d4'
+    version '21.1.0'
+    sha256 '212568a6af374e40537c7180ae28d2083dc4f1ef8bbf26654019b1033a52d06c'
   end
 
   depends_on macos: '>= :mojave'
-  url "https://pm.puppet.com/pe-client-tools/2021.0.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
+  url "https://pm.puppet.com/pe-client-tools/2021.1.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 
   name 'PE Client Tools'

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ To install the latest version of [PE Client Tools](https://puppet.com/docs/pe/la
 brew install puppetlabs/puppet/pe-client-tools
 ```
 
-To install the client tools for PE 2018.1, run
+To install the client tools for PE 2021, run
 
 ```bash
-brew install puppetlabs/puppet/pe-client-tools-2018.1
+brew install puppetlabs/puppet/pe-client-tools
 ```
 
-This will install the stand-lone commands from pe-client-tools to `/opt/puppetlabs/bin` so you'll need to have `/opt/puppetlabs/bin` in your path. All the commands are also available via a puppet face if you have the puppet-agent installed too.
+This will install the standalone commands from pe-client-tools to `/opt/puppetlabs/bin` so you'll need to have `/opt/puppetlabs/bin` in your path. All the commands are also available via a puppet face if you have the puppet-agent installed too.
 
 ### PDK
 
@@ -91,7 +91,6 @@ brew install puppetlabs/puppet/puppet-agent
 ```
 
 Additionally we maintain versioned casks for each collection
-- `puppetlabs/puppet/puppet-agent-5`
 - `puppetlabs/puppet/puppet-agent-6`
 - `puppetlabs/puppet/puppet-agent-7`
 
@@ -141,10 +140,10 @@ When new versions of packages are shipped, you can use a Rake task to update the
 rake 'brew:cask[puppet-bolt]'
 ```
 
-To update the versioned casks - for example `puppet-agent-5` - include the collection as a 2nd argument
+To update the versioned casks - for example `puppet-agent-6` - include the collection as a 2nd argument
 
 ```bash
-rake 'brew:cask[puppet-agent,5]'
+rake 'brew:cask[puppet-agent,6]'
 ```
 
 You can test updated Cask files with
@@ -165,8 +164,6 @@ rake brew:pe_client_tools
 
 # Update the individual PE collections
 rake 'brew:pe_client_tools[2019.8]'
-rake 'brew:pe_client_tools[2019.3]'
-rake 'brew:pe_client_tools[2018.1]'
 ```
 
 Internally, we can look for the available versions by poking around on http://builds.puppetlabs.lan/pe-client-tools/

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ To pull down a new version of the client tools you will first want to update the
 rake brew:pe_client_tools
 
 # Update the individual PE collections
+rake 'brew:pe_client_tools[2019.8]'
 rake 'brew:pe_client_tools[2019.3]'
 rake 'brew:pe_client_tools[2018.1]'
 ```
+
+Internally, we can look for the available versions by poking around on http://builds.puppetlabs.lan/pe-client-tools/

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'net/http'
 require 'tmpdir'
 
 def fetch(uri, limit = 10)
-  # puts "Fetching #{uri}" # Uncomment to debug what UR:'s are being fetched
+  # puts "Fetching #{uri}" # Uncomment to debug what URI's are being fetched
   raise 'too many HTTP redirects' if limit == 0
   response = Net::HTTP.get_response(URI(uri))
   case response
@@ -32,18 +32,18 @@ VERSION_TO_CODENAME = {
   '11'    => :big_sur,
 }
 
-LATEST_PE = '2021.0'
+LATEST_PE = '2021'
 
 CLIENT_TOOLS = {
-  '2021.0' => '21.0.0',
-  '2019.8' => '19.8.5',
+  '2021'   => '21.1.0',
+  '2019.8' => '19.8.6',
 }
 
 def operating_systems(collection)
   case collection
   when 'pct2019.8'
     %w[10.14 10.15]
-  when 'pct2021.0'
+  when 'pct2021'
     %w[10.14 10.15]
   when 'puppet5'
     %w[10.10 10.11 10.12 10.13 10.14 10.15]
@@ -101,7 +101,8 @@ namespace :brew do
     cask += '-' + args[:collection] if args[:collection]
     os_versions = operating_systems("pct#{collection}")
 
-    path_pre = "https://pm.puppet.com/pe-client-tools/#{collection}.0/"
+    pe_ver = CLIENT_TOOLS[collection].dup.prepend('20')
+    path_pre = "https://pm.puppet.com/pe-client-tools/#{pe_ver}/"
 
     latest_versions = os_versions.map do |os_ver|
       version

--- a/Rakefile
+++ b/Rakefile
@@ -32,22 +32,19 @@ VERSION_TO_CODENAME = {
   '11'    => :big_sur,
 }
 
-LATEST_PE = '2019.8'
+LATEST_PE = '2021.0'
 
 CLIENT_TOOLS = {
-  '2019.8' => '19.8.4',
-  '2019.3' => '19.3.0',
-  '2018.1' => '18.1.8',
+  '2021.0' => '21.0.0',
+  '2019.8' => '19.8.5',
 }
 
 def operating_systems(collection)
   case collection
   when 'pct2019.8'
-    %w[10.13 10.14 10.15]
-  when 'pct2019.3'
-    %w[10.12 10.13]
-  when 'pct2018.1'
-    %w[10.12 10.13]
+    %w[10.14 10.15]
+  when 'pct2021.0'
+    %w[10.14 10.15]
   when 'puppet5'
     %w[10.10 10.11 10.12 10.13 10.14 10.15]
   when 'puppet7'

--- a/Rakefile
+++ b/Rakefile
@@ -32,15 +32,18 @@ VERSION_TO_CODENAME = {
   '11'    => :big_sur,
 }
 
-LATEST_PE = '2019.3'
+LATEST_PE = '2019.8'
 
 CLIENT_TOOLS = {
+  '2019.8' => '19.8.4',
   '2019.3' => '19.3.0',
-  '2018.1' => '18.1.3',
+  '2018.1' => '18.1.8',
 }
 
 def operating_systems(collection)
   case collection
+  when 'pct2019.8'
+    %w[10.13 10.14 10.15]
   when 'pct2019.3'
     %w[10.12 10.13]
   when 'pct2018.1'

--- a/templates/pe-client-tools-2019.8.rb.erb
+++ b/templates/pe-client-tools-2019.8.rb.erb
@@ -1,0 +1,7 @@
+cask 'pe-client-tools-2019.8' do
+<%= source_stanza %>
+  name 'PE Client Tools'
+  homepage "https://puppet.com/docs/pe/2019.8/installing_pe_client_tools.html"
+
+  uninstall pkgutil: 'com.puppetlabs.pe-client-tools'
+end


### PR DESCRIPTION
This incorporates the changes from #259 and #273, and removes EOL platform/project combinations from .travis.yml. The readme was also updated to reflect the current supported versions of puppet-agent and pe-client-tools.