### PR TITLE
(maint) Update puppet-bolt to 3.11.0

### DIFF
--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -14,12 +14,16 @@ cask 'puppet-bolt' do
     sha256 'ec644414592e24f685e41f696e9830958b5c2223b7d489038529520faf3d3352'
   when '10.14'
     os_ver = '10.14'
-    version '3.10.0'
-    sha256 'd08a99c4f7e847f1ccbff0d52fd7c38f21b1db2a2997ff0c6155e9514b4643ac'
-  else
+    version '3.11.0'
+    sha256 'e6412fff35f92497ae513fe32cf3c5793b9871c42cf1b6ae1fd7f2f698f2ecc3'
+  when '10.15'
     os_ver = '10.15'
-    version '3.10.0'
-    sha256 'b74707f9460ed88d6b85819ca53ae5033e645b6f2a4312476e5dd159d1f83d54'
+    version '3.11.0'
+    sha256 '02092f9e99039778c373083ab502855b8c0331220e8e03384fc67736105083db'
+  else
+    os_ver = '11'
+    version '3.11.0'
+    sha256 'fc8ae0ad2b6938b532607c6c758573745b44fa038f14fa7c09cd56ccbb5b6ad5'
   end
 
   depends_on macos: '>= :el_capitan'

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,11 @@ CLIENT_TOOLS = {
   '2019.8' => '19.8.6',
 }
 
-def operating_systems(collection)
+def operating_systems(collection, pkg = nil)
+  if %w[puppet-bolt].include?(pkg)
+    return %w[10.11 10.12 10.13 10.14 10.15 11]
+  end
+
   case collection
   when 'pct2019.8'
     %w[10.14 10.15]
@@ -63,7 +67,7 @@ namespace :brew do
     collection = PKG_TO_COLLECTIONS[pkg] || "puppet#{args[:collection]}"
     cask = pkg
     cask += '-' + args[:collection] if args[:collection]
-    os_versions = operating_systems(collection)
+    os_versions = operating_systems(collection, pkg)
 
     path_pre = "https://downloads.puppet.com/mac/#{collection}/"
 


### PR DESCRIPTION
This updates puppet-bolt packages to 3.11.0.

This also updates the rake task to include the macOS 11 package for
puppet-bolt. Previously, the puppet-tools collection was used to
determine the OS versions to include in the puppet-bolt cask. However,
the puppet-tools collection includes pdk, which does not ship for macOS
11 currently, necessitating additional logic to not include macOS 11 in
the list of OS versions for any puppet-tools package other than
puppet-bolt.