### PR TITLE
(PDK-1792) Update PDK for 2.5.0.0

### DIFF
--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -1,32 +1,20 @@
 cask 'pdk' do
   case MacOS.version
-  when '10.11'
-    os_ver = '10.11'
-    version '1.16.0.2'
-    sha256 'ead0d9089225efe5270e59790253011392b02a37d615d82c7d19faa78df1fa4b'
-  when '10.12'
-    os_ver = '10.12'
-    version '1.16.0.2'
-    sha256 '2c1c39ee111be3325c8bc2e36323d3b60d504ba5038053a1aa8d4d3567f79642'
-  when '10.13'
-    os_ver = '10.13'
-    version '1.17.0.0'
-    sha256 'e260500af2cbe07d31b880bffe5c7bcc1b3823cc3472a75829e8a582b197931d'
   when '10.14'
     os_ver = '10.14'
     version '2.3.0.0'
     sha256 '81271634502b0e2f2ed11b07262ceec460f677cf2836af6e0b8ad9eed5e660ef'
   when '10.15'
     os_ver = '10.15'
-    version '2.4.0.1'
-    sha256 '5fb7d2958902c9f6fd197d6ea3406f7ea6e687eef3c7b6cc93bbc13446d4228a'
+    version '2.5.0.0'
+    sha256 'eb58747a34acdba3dc78295f29892b22b80088c622c0416ad81c012e964533e4'
   else
     os_ver = '11'
-    version '2.4.0.1'
-    sha256 '5195c3744213c59ebf5c8d25971d3f88f9d2e63c47fc5dd2ed4d40cc452c5996'
+    version '2.5.0.0'
+    sha256 'ad8ad667505be1cbc9ed45c4f9bc62af3278c5fb61fd4b33cdc4cec18d9055c5'
   end
 
-  depends_on macos: '>= :el_capitan'
+  depends_on macos: '>= :mojave'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 


### PR DESCRIPTION
This PR is the result of `rake brew:cask[pdk]`. Versions have been updated to 2.5.0.0 where applicable and it seems that for 10.14 the last available build was 2.3.0.0.