### PR TITLE
(packaging) Remove deprecated Yosemite dependency

### DIFF
--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -26,7 +26,6 @@ cask 'puppet-agent-5' do
     sha256 '5914ccf0d1c4a90688458fc1cb12ee1282a737e3841f9997975477c7d97baf61'
   end
 
-  depends_on macos: '>= :yosemite'
   url "https://downloads.puppet.com/mac/puppet5/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 


### PR DESCRIPTION
Installing puppet-agent-5 generates the following warning now:

```shellsession
$ brew install puppet-agent-5
Warning: Calling depends_on :macos => :yosemite is deprecated! There is no replacement.
Please report this issue to the puppetlabs/puppet tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/puppetlabs/homebrew-puppet/Casks/puppet-agent-5.rb:29
```

[Per the Homebrew Cask Cookbook][1], the available values for `depends_on macos` now start with `:el_capitan`, so I take it Homebrew no longer supports anything before Yosemite. So removing this line from the Cask definition should fix this warning with no ill effects.

Resolves #347.

[1]: https://docs.brew.sh/Cask-Cookbook#depends_on-macos