### PR TITLE
(PA-4534) Update the shas for 6.28.0 and 7.18.0

### DIFF
--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -14,16 +14,16 @@ cask 'puppet-agent-6' do
     sha256 '8b9a7634fcbc9771f3497d448da073273fb4be1a9a2c82fe79f3a99e53e6f4bb'
   when '10.15'
     os_ver = '10.15'
-    version '6.27.1'
-    sha256 '72a0cfe227d1e8a9dbf0fdde0a289f37af8418901b21e69a9f3baffd6a714c21'
+    version '6.28.0'
+    sha256 '88597e18dff9c738f0a3d5affab54b32e25a39bb171cee3622e49dd9da32b45c'
   when '11'
     os_ver = '11'
-    version '6.27.1'
-    sha256 'b7eb95b7bf15ae3cc9fcecaa8a87446641130f4507c575525310f4ca13b31e58'
+    version '6.28.0'
+    sha256 '2e2eaa07b8b1be952e6c19f64ca4a25870e3e3ceca7fe0547fdc7039684049ae'
   else
     os_ver = '12'
-    version '6.27.1'
-    sha256 '96a39dc55fb54fecbaefcbce119313578d1b34a5b7edf683d9bd7ed188461a73'
+    version '6.28.0'
+    sha256 '09be98465a129ef0657968f8e7efae095c2979506961a60bd8a46144a169036d'
   end
 
   depends_on macos: '>= :sierra'

--- a/Casks/puppet-agent-7.rb
+++ b/Casks/puppet-agent-7.rb
@@ -1,24 +1,20 @@
 cask 'puppet-agent-7' do
   case MacOS.version
-  when '10.14'
-    os_ver = '10.14'
-    version '7.9.0'
-    sha256 '539f2cbacf20bd2bed3bd7f173dc07aa99d9305a8cb91408e450e8b39ba0177d'
   when '10.15'
     os_ver = '10.15'
-    version '7.17.0'
-    sha256 '8c4eff08e57dd12d6e45d1a7ab95980e147321d4c4421208d8dd90450e62e0f0'
+    version '7.18.0'
+    sha256 'be54e95d765fec76a7f38b1586388845abbcc061640d3c9f5afc9ef3981af599'
   when '11'
     os_ver = '11'
-    version '7.17.0'
-    sha256 'c701d2b0eb30614e27ad5358e50537544bf625864fe695963a70260878e7705e'
+    version '7.18.0'
+    sha256 'aa1059aa51ef979b4d47104430afe65f715afb3e496bdc933a2d16d5c20a8fbe'
   else
     os_ver = '12'
-    version '7.17.0'
-    sha256 '3854ced5b4c0315a691bddf666165178f1a164d088c2ffcbe3af108ef8fb04b3'
+    version '7.18.0'
+    sha256 'dd5c3a608793d2e8bb8046357ee4908960afda987e467b6088799594ec2df247'
   end
 
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :catalina'
   url "https://downloads.puppet.com/mac/puppet7/#{os_ver}/x86_64/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Rakefile
+++ b/Rakefile
@@ -50,12 +50,10 @@ def operating_systems(collection, pkg = nil)
     %w[10.14 10.15]
   when 'pct2021'
     %w[10.14 10.15]
-  when 'puppet5'
-    %w[10.10 10.11 10.12 10.13 10.14 10.15]
   when 'puppet7'
-    %w[10.14 10.15 11 12]
+    %w[10.15 11 12]
   when 'puppet'
-    %w[10.14 10.15 11 12]
+    %w[10.15 11 12]
   else
     %w[10.11 10.12 10.13 10.14 10.15 11 12]
   end


### PR DESCRIPTION
Also removed 10.14 since it is EOL for over half a year and we aren't releasing new agents for it.