### PR TITLE
(PA-4620) Create ruby@2.5 formula

### DIFF
--- a/Formula/ruby@2.5.rb
+++ b/Formula/ruby@2.5.rb
@@ -1,0 +1,169 @@
+class RubyAT25 < Formula
+  desc "Powerful, clean, object-oriented scripting language"
+  homepage "https://www.ruby-lang.org/"
+  url "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.xz"
+  sha256 "a87f2fa901408cc77652c1a55ff976695bbe54830ff240e370039eca14b358f0"
+  license "Ruby"
+
+  bottle do
+    sha256 arm64_monterey: "d88a21825cea4e2e1d1382effb53d640c23472e46e3f8b4c3f63e2571e0b37d1"
+    sha256 arm64_big_sur:  "deb2ee5e006f4fc7b3829dfcdb377300f3dc5f339562a6a1c1b4dec48ed21ae6"
+    sha256 monterey:       "67b01aac127e5ffeae54ee90f79aa137f69f2dede97ca3e390a472474ee5e11f"
+    sha256 big_sur:        "fb6b696623fc988abecbf9fb9f5298219c62c69851123b9d9d69c3f127b0ec3c"
+    sha256 catalina:       "8fab1468c593b5907e027c175dc19e3273b08cc8b344822ce593dcab645e857d"
+    sha256 mojave:         "ef4974800a4417e6251fb548486150157c2f0ff62275170431381480bac1c3ed"
+    sha256 x86_64_linux:   "8b85cf06b1f139109bae913ade71190a65fb71f7848d846428cf95dbd0658e05"
+  end
+
+  keg_only :versioned_formula
+
+  deprecate! date: "2021-04-05", because: :unsupported
+
+  depends_on "pkg-config" => :build
+  depends_on "libyaml"
+  depends_on "openssl@1.1"
+  depends_on "readline"
+
+  uses_from_macos "zlib"
+
+  def api_version
+    "2.5.0"
+  end
+
+  def rubygems_bindir
+    HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/bin"
+  end
+
+  def install
+    # otherwise `gem` command breaks
+    ENV.delete("SDKROOT")
+
+    paths = %w[libyaml openssl@1.1 readline].map { |f| Formula[f].opt_prefix }
+    args = %W[
+      --prefix=#{prefix}
+      --enable-shared
+      --disable-silent-rules
+      --with-sitedir=#{HOMEBREW_PREFIX}/lib/ruby/site_ruby
+      --with-vendordir=#{HOMEBREW_PREFIX}/lib/ruby/vendor_ruby
+      --with-opt-dir=#{paths.join(":")}
+      --without-gmp
+    ]
+    args << "--disable-dtrace" if OS.mac? && !MacOS::CLT.installed?
+
+    system "./configure", *args
+
+    # Ruby has been configured to look in the HOMEBREW_PREFIX for the
+    # sitedir and vendordir directories; however we don't actually want to create
+    # them during the install.
+    #
+    # These directories are empty on install; sitedir is used for non-rubygems
+    # third party libraries, and vendordir is used for packager-provided libraries.
+    inreplace "tool/rbinstall.rb" do |s|
+      s.gsub! 'prepare "extension scripts", sitelibdir', ""
+      s.gsub! 'prepare "extension scripts", vendorlibdir', ""
+      s.gsub! 'prepare "extension objects", sitearchlibdir', ""
+      s.gsub! 'prepare "extension objects", vendorarchlibdir', ""
+    end
+
+    system "make"
+    system "make", "install"
+
+    # A newer version of ruby-mode.el is shipped with Emacs
+    elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
+  end
+
+  def post_install
+    # Customize rubygems to look/install in the global gem directory
+    # instead of in the Cellar, making gems last across reinstalls
+    config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
+    config_file.unlink if config_file.exist?
+    config_file.write rubygems_config
+
+    # Create the sitedir and vendordir that were skipped during install
+    %w[sitearchdir vendorarchdir].each do |dir|
+      mkdir_p `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["#{dir}"]'`
+    end
+  end
+
+  def rubygems_config
+    <<~EOS
+      module Gem
+        class << self
+          alias :old_default_dir :default_dir
+          alias :old_default_path :default_path
+          alias :old_default_bindir :default_bindir
+          alias :old_ruby :ruby
+        end
+
+        def self.default_dir
+          path = [
+            "#{HOMEBREW_PREFIX}",
+            "lib",
+            "ruby",
+            "gems",
+            "#{api_version}"
+          ]
+
+          @default_dir ||= File.join(*path)
+        end
+
+        def self.private_dir
+          path = if defined? RUBY_FRAMEWORK_VERSION then
+                   [
+                     File.dirname(RbConfig::CONFIG['sitedir']),
+                     'Gems',
+                     RbConfig::CONFIG['ruby_version']
+                   ]
+                 elsif RbConfig::CONFIG['rubylibprefix'] then
+                   [
+                    RbConfig::CONFIG['rubylibprefix'],
+                    'gems',
+                    RbConfig::CONFIG['ruby_version']
+                   ]
+                 else
+                   [
+                     RbConfig::CONFIG['libdir'],
+                     ruby_engine,
+                     'gems',
+                     RbConfig::CONFIG['ruby_version']
+                   ]
+                 end
+
+          @private_dir ||= File.join(*path)
+        end
+
+        def self.default_path
+          if Gem.user_home && File.exist?(Gem.user_home)
+            [user_dir, default_dir, private_dir]
+          else
+            [default_dir, private_dir]
+          end
+        end
+
+        def self.default_bindir
+          "#{rubygems_bindir}"
+        end
+
+        def self.ruby
+          "#{opt_bin}/ruby"
+        end
+      end
+    EOS
+  end
+
+  def caveats
+    <<~EOS
+      By default, binaries installed by gem will be placed into:
+        #{rubygems_bindir}
+
+      You may want to add this to your PATH.
+    EOS
+  end
+
+  test do
+    hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
+    assert_equal "hello\n", hello_text
+    ENV["GEM_HOME"] = testpath
+    system "#{bin}/gem", "install", "json"
+  end
+end


### PR DESCRIPTION
Homebrew no longer supports ruby 2.5, but we need that version installed
when cross-compiling puppet-agent 6/Ruby 2.5 on macOS 11/12 M1. We plan
on moving away from cross-compiling on macOS, but for now copy the
formula from upstream:

https://github.com/Homebrew/homebrew-core/blob/39fc09c6dd0baecdb7334f25eeeca6a6706432ec/Formula/ruby%402.5.rb