### PR TITLE
(PA-4564) Puppet 5 is EOL

### DIFF
--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -43,4 +43,13 @@ cask 'puppet-agent-5' do
                '~/.puppetlabs',
                '/etc/puppetlabs',
              ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      #{token} has been deprecated in favor of puppet-agent-7.
+        brew install --cask puppet-agent-7
+    EOS
+  end
 end


### PR DESCRIPTION
This produces the following:

    $ brew install puppetlabs/puppet
    ...
    ==> Caveats
    puppet-agent-5 has been deprecated in favor of puppet-agent-7.
      brew install --cask puppet-agent-7

    puppet-agent-5 has been officially discontinued upstream.
    It may stop working correctly (or at all) in recent versions of macOS.