### PR TITLE
Release puppet bolt 3.26.2

### DIFF
--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -1,37 +1,71 @@
 cask 'puppet-bolt' do
+  if MacOS.version < :catalina
+    arch = 'x86_64'
+  else
+    arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
+  end
+
   case MacOS.version
   when '10.11'
     os_ver = '10.11'
     version '2.0.0'
-    sha256 'a5956c7d075a6219f04cda8890732bb8e31b4e10ad0096e18046531b43cfdd7d'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 'a5956c7d075a6219f04cda8890732bb8e31b4e10ad0096e18046531b43cfdd7d'
+    end
   when '10.12'
     os_ver = '10.12'
     version '2.0.0'
-    sha256 '9d14f5106bb1c882971658ca00537fd1f1e176685f31588637eab8b95feba0d7'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 '9d14f5106bb1c882971658ca00537fd1f1e176685f31588637eab8b95feba0d7'
+    end
   when '10.13'
     os_ver = '10.13'
     version '2.0.0'
-    sha256 'ec644414592e24f685e41f696e9830958b5c2223b7d489038529520faf3d3352'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 'ec644414592e24f685e41f696e9830958b5c2223b7d489038529520faf3d3352'
+    end
   when '10.14'
     os_ver = '10.14'
     version '3.13.0'
-    sha256 '22dc674608197d63c5c1bd199dc4337eff2822ea6cb9fefab3a1cc4ee3ec7187'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 '22dc674608197d63c5c1bd199dc4337eff2822ea6cb9fefab3a1cc4ee3ec7187'
+    end
   when '10.15'
     os_ver = '10.15'
     version '3.22.1'
-    sha256 '4f17695d85a321260a5d60ab67a490c99cb27be9cdb83ef50e906be36163fb24'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 '4f17695d85a321260a5d60ab67a490c99cb27be9cdb83ef50e906be36163fb24'
+    end
   when '11'
     os_ver = '11'
-    version '3.26.1'
-    sha256 '30d98cdc4aa9a5c28353d999b2968e625277756c87e1f49d83d0886b209d8064'
+    version '3.26.2'
+    if arch == 'arm64'
+      sha256 'nil'
+    elsif arch == 'x86_64'
+      sha256 'abb6482d9fa2c48e532339cd5fc0befe57d13f9e2530f4edc306657565e7d9c5'
+    end
   else
     os_ver = '12'
-    version '3.26.1'
-    sha256 '348f796687ac923651703e2e99a15e67fd2c9045b9b564e845501ab8f4f9720e'
+    version '3.26.2'
+    if arch == 'x86_64'
+      sha256 '3e86a1ce72ad1df62ba8491383f7c0a2c4513ed8359cd4973e9e27c98588f7e3'
+    elsif arch == 'arm64'
+      sha256 'nil'
+    end
   end
 
   depends_on macos: '>= :el_capitan'
-  url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
+  url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/#{arch}/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 
   name 'Puppet Bolt'

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ namespace :brew do
         resp = fetch("#{path_pre}#{os_ver}/x86_64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
         x86_64_sha = Digest::SHA256.hexdigest(resp.body)
         arm64_sha = 'nil'
-        if os_ver.to_i >= 11
+        if pkg == 'puppet-agent' && os_ver.to_i >= 11
           resp_arm64 = fetch("#{path_pre}#{os_ver}/arm64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
           arm64_sha  = Digest::SHA256.hexdigest(resp_arm64.body)
         end

--- a/templates/puppet-bolt.rb.erb
+++ b/templates/puppet-bolt.rb.erb
@@ -1,4 +1,10 @@
 cask 'puppet-bolt' do
+  if MacOS.version < :catalina
+    arch = 'x86_64'
+  else
+    arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
+  end
+
 <%= source_stanza %>
   name 'Puppet Bolt'
   homepage 'https://github.com/puppetlabs/bolt'


### PR DESCRIPTION
also

    (maint) Guard cask:brew task arm64 lookup for non puppet-agent

b92dab4 updated the Rakefile to lookup arm64 shas for puppet-agent.
Bolt doesn't have arm64 packages (BOLT-1604 is pending). Right now only
puppet-agent has arm64 packages so added a check for pkg to skip
attempting to fetch arm64 if not puppet-agent.