### PR TITLE
(maint) Continue to install x86 packages on ARM for bolt

### DIFF
--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -1,9 +1,13 @@
 cask 'puppet-bolt' do
-  if MacOS.version < :catalina
-    arch = 'x86_64'
-  else
-    arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
-  end
+  ## TODO: BOLT-1604, enable this when we build packsages for ARM.
+  ## For now the x86 emulator on mac seems to work well enough (and users are already on it),
+  ## so just statically set arch to x86_64 now
+  arch = 'x86_64'
+  # if MacOS.version < :catalina
+  #   arch = 'x86_64'
+  # else
+  #   arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
+  # end
 
   case MacOS.version
   when '10.11'

--- a/templates/puppet-bolt.rb.erb
+++ b/templates/puppet-bolt.rb.erb
@@ -1,9 +1,13 @@
 cask 'puppet-bolt' do
-  if MacOS.version < :catalina
-    arch = 'x86_64'
-  else
-    arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
-  end
+  ## TODO: BOLT-1604, enable this when we build packsages for ARM.
+  ## For now the x86 emulator on mac seems to work well enough (and users are already on it),
+  ## so just statically set arch to x86_64 now
+  arch = 'x86_64'
+  # if MacOS.version < :catalina
+  #   arch = 'x86_64'
+  # else
+  #   arch = Hardware::CPU.intel? ? 'x86_64' : 'arm64'
+  # end
 
 <%= source_stanza %>
   name 'Puppet Bolt'


### PR DESCRIPTION
The x86 emulator for macOS has been working for existing bolt users. This commit backs out a change from https://github.com/puppetlabs/homebrew-puppet/pull/365 while providing a path forward for when we do get to packaging for ARM.