### PR TITLE
(PA-5603) Update for puppet-agent's 7.25.0 and 8.1.0

### DIFF
--- a/Casks/puppet-agent-7.rb
+++ b/Casks/puppet-agent-7.rb
@@ -6,29 +6,21 @@ cask 'puppet-agent-7' do
   end
 
   case MacOS.version
-  when '10.15'
-    os_ver = '10.15'
-    version '7.24.0'
-    if arch == 'arm64'
-      sha256 'nil'
-    elsif arch == 'x86_64'
-      sha256 '33dfbd3214eb3cbfa319425ac54106699a27f94a9b04fb39995979056464ffe9'
-    end
   when '11'
     os_ver = '11'
-    version '7.24.0'
+    version '7.25.0'
     if arch == 'arm64'
-      sha256 '33e1e315ee90441faf34062df50136a32dd5a5fb6c46ed88d862b14a6ea5b438'
+      sha256 'e3b24be25b08726074fb3d76abfbe59291b383ce874da6af0c2f80da66b1bac6'
     elsif arch == 'x86_64'
-      sha256 '00bd110c26ae3479fa410469969ece3f5159240fcff188af26f1afc4b24cf2c2'
+      sha256 '257ce39fc5d761873e61efedaf655ffc4c8e7f86642481387ee1af662bb03741'
     end
   else
     os_ver = '12'
-    version '7.24.0'
+    version '7.25.0'
     if arch == 'x86_64'
-      sha256 '492fb1dc3fb1da1fb9f10bb21dd8a4f39bc2d77eb07b129ca8b04f0d36cabc58'
+      sha256 'b2bfd5581bfc1c5412d17dcd7b5e2d307f9d4d55e63a0a72cb11a657885009c0'
     elsif arch == 'arm64'
-      sha256 'ad37f0acbdd78b0af785419bde9bbf44a03d01cf3392baafd8c68c432a811577'
+      sha256 '8cb860ecdb2f7222088146769a47f0b2dc3d3176a836e3011239221511b8d71f'
     end
   end
 

--- a/Casks/puppet-agent-8.rb
+++ b/Casks/puppet-agent-8.rb
@@ -8,17 +8,17 @@ cask 'puppet-agent-8' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '8.0.0'
+    version '8.1.0'
     if arch == 'arm64'
       sha256 'nil'
     elsif arch == 'x86_64'
-      sha256 '6282522db6697469297f634479c0c7fe63c65ea8cd7f82647aafc2373e6dc580'
+      sha256 '83bce32591927318ace67664038ce40153b06aab5358a3f3452cd54508c4d5c5'
     end
   else
     os_ver = '12'
-    version '8.0.0'
+    version '8.1.0'
     if arch == 'x86_64'
-      sha256 '5f91c7c5a90ef7ff972c376625e29a9799cf1f0764164d0665c99298eb8445e5'
+      sha256 'ba41de1897a09aed6da5e5afdef6b4a6622ff034bf919d3eb7fd7b21b086994d'
     elsif arch == 'arm64'
       sha256 'nil'
     end

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -6,29 +6,21 @@ cask 'puppet-agent' do
   end
 
   case MacOS.version
-  when '10.15'
-    os_ver = '10.15'
-    version '7.24.0'
-    if arch == 'arm64'
-      sha256 'nil'
-    elsif arch == 'x86_64'
-      sha256 '33dfbd3214eb3cbfa319425ac54106699a27f94a9b04fb39995979056464ffe9'
-    end
   when '11'
     os_ver = '11'
-    version '7.24.0'
+    version '7.25.0'
     if arch == 'arm64'
-      sha256 '33e1e315ee90441faf34062df50136a32dd5a5fb6c46ed88d862b14a6ea5b438'
+      sha256 'e3b24be25b08726074fb3d76abfbe59291b383ce874da6af0c2f80da66b1bac6'
     elsif arch == 'x86_64'
-      sha256 '00bd110c26ae3479fa410469969ece3f5159240fcff188af26f1afc4b24cf2c2'
+      sha256 '257ce39fc5d761873e61efedaf655ffc4c8e7f86642481387ee1af662bb03741'
     end
   else
     os_ver = '12'
-    version '7.24.0'
+    version '7.25.0'
     if arch == 'x86_64'
-      sha256 '492fb1dc3fb1da1fb9f10bb21dd8a4f39bc2d77eb07b129ca8b04f0d36cabc58'
+      sha256 'b2bfd5581bfc1c5412d17dcd7b5e2d307f9d4d55e63a0a72cb11a657885009c0'
     elsif arch == 'arm64'
-      sha256 'ad37f0acbdd78b0af785419bde9bbf44a03d01cf3392baafd8c68c432a811577'
+      sha256 '8cb860ecdb2f7222088146769a47f0b2dc3d3176a836e3011239221511b8d71f'
     end
   end
 


### PR DESCRIPTION
Also dropping support for macos 10.15.