### PR TITLE
Add puppet-agent 7.26.0 and 8.2.0

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install ${{ matrix.cask }} cask on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-11', 'macos-12' ]
+        macos: [ 'macos-11', 'macos-12', 'macos-13' ]
         cask: [ 'pe-client-tools', 'pe-client-tools-2019.8', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs

--- a/Casks/puppet-agent-7.rb
+++ b/Casks/puppet-agent-7.rb
@@ -8,23 +8,31 @@ cask 'puppet-agent-7' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '7.25.0'
+    version '7.26.0'
     if arch == 'arm64'
-      sha256 'e3b24be25b08726074fb3d76abfbe59291b383ce874da6af0c2f80da66b1bac6'
+      sha256 'eb4398daf3647f6bcc6c387b4049c8d74b634afe45a286335f5d762c6b5c5fbf'
     elsif arch == 'x86_64'
-      sha256 '257ce39fc5d761873e61efedaf655ffc4c8e7f86642481387ee1af662bb03741'
+      sha256 'ae6a44ca69a357018445da3089a19627c3330330176991d266bcc9db676c6ae4'
+    end
+  when '12'
+    os_ver = '12'
+    version '7.26.0'
+    if arch == 'arm64'
+      sha256 '21c3103915742b6e8a4ec93f6d55c48e9ec4161809168a53a60819b8c173c6df'
+    elsif arch == 'x86_64'
+      sha256 'af86dcf0645dbd274a116b9eed069e8f4667b663bbca85524bad5e157d3435c1'
     end
   else
-    os_ver = '12'
-    version '7.25.0'
+    os_ver = '13'
+    version '7.26.0'
     if arch == 'x86_64'
-      sha256 'b2bfd5581bfc1c5412d17dcd7b5e2d307f9d4d55e63a0a72cb11a657885009c0'
+      sha256 '72a03a71c11df96954f169a5ce36c66d94ffedb843ec637338311f8630ecc7b7'
     elsif arch == 'arm64'
-      sha256 '8cb860ecdb2f7222088146769a47f0b2dc3d3176a836e3011239221511b8d71f'
+      sha256 '72c3539a440fb84c8ece5b6ed84f9f3878b0640c0d40357e6764edc26888f384'
     end
   end
 
-  depends_on macos: '>= :catalina'
+  depends_on macos: '>= :big_sur'
   url "https://downloads.puppet.com/mac/puppet7/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-8.rb
+++ b/Casks/puppet-agent-8.rb
@@ -8,19 +8,27 @@ cask 'puppet-agent-8' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '8.1.0'
+    version '8.2.0'
     if arch == 'arm64'
       sha256 'nil'
     elsif arch == 'x86_64'
-      sha256 '83bce32591927318ace67664038ce40153b06aab5358a3f3452cd54508c4d5c5'
+      sha256 '82fea415c6104f93b55f78d0f778fbeca63e0f2e2fc360882eba8550d33bc833'
+    end
+  when '12'
+    os_ver = '12'
+    version '8.2.0'
+    if arch == 'arm64'
+      sha256 '4a6451f68f411ba7b3fa37d73e7b8c847b766bab6a0bc583effff33ca3b1be0e'
+    elsif arch == 'x86_64'
+      sha256 '794fd4d7c2bef6db359ca57b99842b31e0e9db8080f1b322034d0153c7cdd958'
     end
   else
-    os_ver = '12'
-    version '8.1.0'
+    os_ver = '13'
+    version '8.2.0'
     if arch == 'x86_64'
-      sha256 'ba41de1897a09aed6da5e5afdef6b4a6622ff034bf919d3eb7fd7b21b086994d'
+      sha256 '7f4731352886120fdf1eb201f4c3b146224907d35f6cbf14145aff26413988cd'
     elsif arch == 'arm64'
-      sha256 'nil'
+      sha256 '2bd11dbb7b1ed570b197638abf0e102ade0d029bd41fcd7bb914cc7c0658d5ff'
     end
   end
 

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -8,23 +8,31 @@ cask 'puppet-agent' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '7.25.0'
+    version '7.26.0'
     if arch == 'arm64'
-      sha256 'e3b24be25b08726074fb3d76abfbe59291b383ce874da6af0c2f80da66b1bac6'
+      sha256 'eb4398daf3647f6bcc6c387b4049c8d74b634afe45a286335f5d762c6b5c5fbf'
     elsif arch == 'x86_64'
-      sha256 '257ce39fc5d761873e61efedaf655ffc4c8e7f86642481387ee1af662bb03741'
+      sha256 'ae6a44ca69a357018445da3089a19627c3330330176991d266bcc9db676c6ae4'
+    end
+  when '12'
+    os_ver = '12'
+    version '7.26.0'
+    if arch == 'arm64'
+      sha256 '21c3103915742b6e8a4ec93f6d55c48e9ec4161809168a53a60819b8c173c6df'
+    elsif arch == 'x86_64'
+      sha256 'af86dcf0645dbd274a116b9eed069e8f4667b663bbca85524bad5e157d3435c1'
     end
   else
-    os_ver = '12'
-    version '7.25.0'
+    os_ver = '13'
+    version '7.26.0'
     if arch == 'x86_64'
-      sha256 'b2bfd5581bfc1c5412d17dcd7b5e2d307f9d4d55e63a0a72cb11a657885009c0'
+      sha256 '72a03a71c11df96954f169a5ce36c66d94ffedb843ec637338311f8630ecc7b7'
     elsif arch == 'arm64'
-      sha256 '8cb860ecdb2f7222088146769a47f0b2dc3d3176a836e3011239221511b8d71f'
+      sha256 '72c3539a440fb84c8ece5b6ed84f9f3878b0640c0d40357e6764edc26888f384'
     end
   end
 
-  depends_on macos: '>= :catalina'
+  depends_on macos: '>= :big_sur'
   url "https://downloads.puppet.com/mac/puppet/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Rakefile
+++ b/Rakefile
@@ -56,9 +56,9 @@ def operating_systems(collection, pkg = nil)
   when 'pct2021'
     %w[10.14 10.15]
   when 'puppet7'
-    %w[10.15 11 12 13]
+    %w[11 12 13]
   when 'puppet'
-    %w[10.15 11 12 13]
+    %w[11 12 13]
   when 'puppet8'
     %w[11 12 13]
   else

--- a/Rakefile
+++ b/Rakefile
@@ -91,7 +91,7 @@ namespace :brew do
         resp = fetch("#{path_pre}#{os_ver}/x86_64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
         x86_64_sha = Digest::SHA256.hexdigest(resp.body)
         arm64_sha = 'nil'
-        if pkg == 'puppet-agent' && os_ver.to_i > 11 && cask == 'puppet-8 '|| pkg == 'puppet-agent' && os_ver.to_i >= 11 && cask == 'puppet7'
+        if pkg == 'puppet-agent' && os_ver.to_i > 11 && cask == 'puppet-agent-8' || pkg == 'puppet-agent' && cask != 'puppet-agent-8'
           resp_arm64 = fetch("#{path_pre}#{os_ver}/arm64/#{pkg}-#{pkg_ver}-1.osx#{os_ver}.dmg")
           arm64_sha  = Digest::SHA256.hexdigest(resp_arm64.body)
         end

--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,7 @@ VERSION_TO_CODENAME = {
   '10.15' => :catalina,
   '11'    => :big_sur,
   '12'    => :monterey,
+  '13'    => :ventura,
 }
 
 LATEST_PE = '2021'
@@ -55,13 +56,13 @@ def operating_systems(collection, pkg = nil)
   when 'pct2021'
     %w[10.14 10.15]
   when 'puppet7'
-    %w[10.15 11 12]
+    %w[10.15 11 12 13]
   when 'puppet'
-    %w[10.15 11 12]
+    %w[10.15 11 12 13]
   when 'puppet8'
-    %w[11 12]
+    %w[11 12 13]
   else
-    %w[10.11 10.12 10.13 10.14 10.15 11 12]
+    %w[10.11 10.12 10.13 10.14 10.15 11 12 13]
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -101,9 +101,9 @@ namespace :brew do
 
     url = "#{path_pre}"+'#{os_ver}/#{arch}/'+pkg+'-#{version}-1.osx#{os_ver}.dmg'
 
-    source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), 0, '-').result(binding)
+    source_stanza = ERB.new(File.read(File.join(__dir__, 'templates', "source_stanza.erb")), trim_mode: '-').result(binding)
 
-    cask_erb = ERB.new(File.read(File.join(__dir__, 'templates', "#{cask}.rb.erb")), 0, '-')
+    cask_erb = ERB.new(File.read(File.join(__dir__, 'templates', "#{cask}.rb.erb")), trim_mode: '-')
     File.write(File.join(__dir__, 'Casks', "#{cask}.rb"), cask_erb.result(binding))
   end
 


### PR DESCRIPTION
This PR:

- Adds the latest two puppet-agents to casks
- Adds support for macOS 13
- Removes support for macOS 10.15
- Updates some deprecated code and logic behaving unexpectedly