### PR TITLE
(PA-5799) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: brew install --cask Casks/${{ matrix.cask }}.rb --force
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: brew install Formula/${{ matrix.formula }}.rb


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.