### PR TITLE
(maint) Update CODEOWNERS 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 *                  @MikaelSmith
 */wash.*           @puppetlabs/wash
 */puppet-bolt.*    @puppetlabs/bolt
-*/pdk.*            @puppetlabs/tooling
+*/pdk.*            @puppetlabs/devx
 */puppet-agent*    @puppetlabs/phoenix
 */pe-client-tools* @puppetlabs/skeletor
 */relay.*          @puppetlabs/relay-community


### PR DESCRIPTION
Updating the CODEOWNERS from tooling to devx to align with team ownership. This will also resolve one of the errors in the CODEWOWNERS file as 'tooling' team did not have permissions on the repo.