### PR TITLE
Add macOS 14 (Sonoma) to install matrix

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install ${{ matrix.cask }} cask on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-11', 'macos-12', 'macos-13' ]
+        macos: [ 'macos-11', 'macos-12', 'macos-13', 'macos-14' ]
         cask: [ 'pe-client-tools', 'pe-client-tools-2019.8', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs


### PR DESCRIPTION
This commit adds a macOS 14 (Sonoma) GitHub Actions runner to the installation matrix used to test various Puppet projects.