### PR TITLE
Maint/master/update puppet agents

### DIFF
--- a/Casks/puppet-agent-7.rb
+++ b/Casks/puppet-agent-7.rb
@@ -8,35 +8,35 @@ cask 'puppet-agent-7' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '7.30.0'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 'd18c1d9e69ae9afea562051da30be6e8798b316beea8e11b7fd47d3b005092c9'
+      sha256 'b36dbf6b597cdbbbded624bd0fc5216adc8d3ea89f645680abbb17ae0f4012fe'
     elsif arch == 'x86_64'
-      sha256 '6ee542e383a225e3dd31c2997a5c44d1c3989476d34db1486f8c8e386cea00ee'
+      sha256 'b6851e802aa76745e434d84107ff82e93764d2e810774b05ea8897abe203220e'
     end
   when '12'
     os_ver = '12'
-    version '7.30.0'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 '3d090b7650796f7f3b8226dfe5c6eb10e1cbe8a4df16b0d792a4612522e20d85'
+      sha256 'f423fd9f142acd0fefeabfa4154c4dbee70a85b28d67a8b1ee28502fd9d1ba0b'
     elsif arch == 'x86_64'
-      sha256 '5968c759afb09b85aa8619c2f372e2c43e0c0ed24f06f840335a178f22b0c0b5'
+      sha256 'b4850e3312287d5dc37039249594d199dbd5fe5be3c4caa3a6cf2c7973570e62'
     end
   when '13'
     os_ver = '13'
-    version '7.30.0'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 'b24c0ad1869103aa37f000a33871464ef7cb078939929c6e9506c830b2006b61'
+      sha256 '63281828da6fe1b2ddff2ad8e536136a6626911ba40e51deec1420c43e7ea2fc'
     elsif arch == 'x86_64'
-      sha256 'be503370b6e41fdd46ef6622822179abeb5c71b7bb1b8b703605dd81e61a7da1'
+      sha256 '6f747aa90b22515e13da4b786804b7c5f28deb8e3d77a1b7bfa959b02b01d72e'
     end
   else
     os_ver = '14'
-    version '7.30.0'
+    version '7.31.0'
     if arch == 'x86_64'
-      sha256 '285ba352e5f294363c21015c6a2b9d859a3e840f1ab7f5d6a1de0269c9318dab'
+      sha256 '5b05d7b511d63d6b35c23bc3e3f5be39d431e5a11a9503d398a6c40bcdd69f12'
     elsif arch == 'arm64'
-      sha256 '8656f39f5831debcdcfc52965155eacb6bb6825c1b8161cbdaf6e493357dcc9e'
+      sha256 'e7ebb0eaef52349f35cb25c71b5be2986cf13f9fb0c54900ab128ea599a12bdb'
     end
   end
 

--- a/Casks/puppet-agent-8.rb
+++ b/Casks/puppet-agent-8.rb
@@ -8,35 +8,35 @@ cask 'puppet-agent-8' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '8.6.0'
+    version '8.7.0'
     if arch == 'arm64'
       sha256 'nil'
     elsif arch == 'x86_64'
-      sha256 '955d3beeeb89b17cb0d5b0e32ad94ecfb46a051d1be8ddd768df21733e42e74d'
+      sha256 'd1243a0c4cf360e7f84048163599878339ffd63cbd27a5ec8cbc6912258fdd59'
     end
   when '12'
     os_ver = '12'
-    version '8.6.0'
+    version '8.7.0'
     if arch == 'arm64'
-      sha256 'ea4ad403099617a2644852acd3696abb95eb13f04676f7aee3d57b9a6e0eaa7f'
+      sha256 'f001c4f794da5f4a983f90bf1ff9560abf7e6c82f2c8ad5b7bcfdff682781476'
     elsif arch == 'x86_64'
-      sha256 'edb9f476a6c96792b21ba21fc03c51424dd06f342e677179d813f79399c10646'
+      sha256 'cce23d66942d52ffc7279fccb85b536dce2888bb836204c1ae33c4c10cfd257d'
     end
   when '13'
     os_ver = '13'
-    version '8.6.0'
+    version '8.7.0'
     if arch == 'arm64'
-      sha256 '8b1e3d8e3b9c74a84e5eb2cef3200d655607261a42b7e68af0631cc4c44071ba'
+      sha256 '5bcd7672431c5f0f234714407d7bd9a8b2296dd98e35aa30ae227c77592d1e18'
     elsif arch == 'x86_64'
-      sha256 '2f2cf840b821236eee1a9d4c0507601ec2d3bb4f5c760d3abddb3af8e45f83dc'
+      sha256 '773cd3243e2cd82611f71b4f57dca8040eed4d496bdf293af204bf7aff42b7b6'
     end
   else
     os_ver = '14'
-    version '8.6.0'
+    version '8.7.0'
     if arch == 'x86_64'
-      sha256 '5045f2de5daf9872a5e9d4965d9ac9127918fb819acc376c00142594fc56bc9a'
+      sha256 '4b3a0bce1ba33f00570d168f29e530f378de9f0c644cef89093b58f974c48711'
     elsif arch == 'arm64'
-      sha256 '83c569165474b50b41e3f42a6d2afb0d7e2bbb92282de0c1721d85a1bf4ef206'
+      sha256 '447299a15cfc0b0c63e75e48c2c8e3385002f5a2a72e71a7078fa5e9d0eb6dfd'
     end
   end
 

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -8,35 +8,35 @@ cask 'puppet-agent' do
   case MacOS.version
   when '11'
     os_ver = '11'
-    version '7.29.1'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 '1a7f2116fd1ec5adcc4a9883eb5b70208a0653af795815a62ccdde1bcc33a8c0'
+      sha256 'b36dbf6b597cdbbbded624bd0fc5216adc8d3ea89f645680abbb17ae0f4012fe'
     elsif arch == 'x86_64'
-      sha256 '70a472fa21c04d9a477aa269b9c359ff19734da0e390ba4ecfae3a485758ab47'
+      sha256 'b6851e802aa76745e434d84107ff82e93764d2e810774b05ea8897abe203220e'
     end
   when '12'
     os_ver = '12'
-    version '7.29.1'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 'a536045668d969e8155a3a78e2359719c0d09187e96416fa69d0810d92cb98e7'
+      sha256 'f423fd9f142acd0fefeabfa4154c4dbee70a85b28d67a8b1ee28502fd9d1ba0b'
     elsif arch == 'x86_64'
-      sha256 '56f4662796100f85207d0d61e3fd874a20b595aae326d97f99f7161493109ee7'
+      sha256 'b4850e3312287d5dc37039249594d199dbd5fe5be3c4caa3a6cf2c7973570e62'
     end
   when '13'
     os_ver = '13'
-    version '7.29.1'
+    version '7.31.0'
     if arch == 'arm64'
-      sha256 '3e5e28f608956447166b2173081153523a7c313536a8e51c445184a23dc1389c'
+      sha256 '63281828da6fe1b2ddff2ad8e536136a6626911ba40e51deec1420c43e7ea2fc'
     elsif arch == 'x86_64'
-      sha256 '516eef7700795629ea26125e855bede8a4d45169be07f16e3a18155b0185bce7'
+      sha256 '6f747aa90b22515e13da4b786804b7c5f28deb8e3d77a1b7bfa959b02b01d72e'
     end
   else
     os_ver = '14'
-    version '7.29.1'
+    version '7.31.0'
     if arch == 'x86_64'
-      sha256 '2ea853aea0b1658d1b89b86e3cbef81adee3873aa2b162c9dc1c475268617461'
+      sha256 '5b05d7b511d63d6b35c23bc3e3f5be39d431e5a11a9503d398a6c40bcdd69f12'
     elsif arch == 'arm64'
-      sha256 '0113172edca88faffb205e7ecfc18e7980d763513fc1e96830948245d9bc1ed2'
+      sha256 'e7ebb0eaef52349f35cb25c71b5be2986cf13f9fb0c54900ab128ea599a12bdb'
     end
   end
 


### PR DESCRIPTION
Update our homebrew tap for the new agent releases 7.31.0 and 8.7.0