### PR TITLE
Removes macOS 11 runners

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install ${{ matrix.cask }} cask on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-11', 'macos-12', 'macos-13', 'macos-14' ]
+        macos: [ 'macos-12', 'macos-13', 'macos-14' ]
         cask: [ 'pe-client-tools', 'pe-client-tools-2019.8', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs
@@ -31,7 +31,7 @@ jobs:
     name: Install ${{ matrix.formula }} formula on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-11', 'macos-12' ]
+        macos: [ 'macos-12' ]
         formula: [ 'relay', 'kubectl-ran' ]
     runs-on: ${{ matrix.macos }}
     steps:


### PR DESCRIPTION
macOS 11 (Big Sur) went end-of-life in 2023 and GitHub removed its macos-11 runners on June 28th, 2024: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

This commit removes macos-11 runners from our tests.