### PR TITLE
Remove Monterey, 2019.8 client tools

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install ${{ matrix.cask }} cask on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-12', 'macos-13', 'macos-14' ]
+        macos: [ 'macos-13', 'macos-14' ]
         cask: [ 'pe-client-tools', 'pe-client-tools-2019.8', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs
@@ -31,7 +31,7 @@ jobs:
     name: Install ${{ matrix.formula }} formula on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-12' ]
+        macos: [ 'macos-13' ]
         formula: [ 'kubectl-ran' ]
     runs-on: ${{ matrix.macos }}
     steps:

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         macos: [ 'macos-13', 'macos-14' ]
-        cask: [ 'pe-client-tools', 'pe-client-tools-2019.8', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
+        cask: [ 'pe-client-tools', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs
       HOMEBREW_TEMP: ~/homebrew-temp


### PR DESCRIPTION
This PR removes end-of-life versions of macOS and the end-of-life PE 2019.8 client tools.