### PR TITLE
Disable EOL agent casks

### DIFF
--- a/Casks/puppet-agent-5.rb
+++ b/Casks/puppet-agent-5.rb
@@ -44,12 +44,5 @@ cask 'puppet-agent-5' do
                '/etc/puppetlabs',
              ]
 
-  caveats do
-    discontinued
-
-    <<~EOS
-      #{token} has been deprecated in favor of puppet-agent-7.
-        brew install --cask puppet-agent-7
-    EOS
-  end
+  disable! date: "2024-12-10", because: :deprecated_upstream
 end

--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -74,12 +74,5 @@ cask 'puppet-agent-6' do
                '/etc/puppetlabs',
              ]
 
-  caveats do
-    discontinued
-
-    <<~EOS
-      #{token} has been deprecated in favor of puppet-agent-7.
-        brew install --cask puppet-agent-7
-    EOS
-  end
+  disable! date: "2024-12-10", because: :deprecated_upstream
 end


### PR DESCRIPTION
Puppet 5 and 6 have been end-of-life for over a year. This commit disables those casks.