### PR TITLE
(PA-8072) Create formula for precompiled bottles

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -1,0 +1,35 @@
+class Cmake < Formula
+  desc "Cross-platform make"
+  homepage "https://www.cmake.org/"
+  url "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/cmake-3.31.6.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/legacy/cmake-3.31.6.tar.gz"
+  sha256 "653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0"
+  license "BSD-3-Clause"
+  head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
+
+  # The "latest" release on GitHub has been an unstable version before, and
+  # there have been delays between the creation of a tag and the corresponding
+  # release, so we check the website's downloads page instead.
+  livecheck do
+    url "https://cmake.org/download/"
+    regex(/href=.*?cmake[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "755552ccd83c7342624996860b9f18b08b02c5f722ba6ddfb7eed167a9748c1f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4a3c640a30ae5aa8f083956aeda589e07b3c0ee4e3c1a0e8ad8d35a64add4367"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "36c5d06776a711a2113344e8936e524b5b45c2bce54494a25dc8cc79a107a497"
+    sha256 cellar: :any_skip_relocation, sequoia:       "d269c0d7f1aec83dbb11888a05858b3000a32a0f692ee6a9e5857ec63ab078b6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "29e93d4eba2852f295d041870b5b09b3b2b623debc05401fa7d4258ca5f9ef4a"
+    sha256 cellar: :any_skip_relocation, ventura:       "25245623b0a79c06783a9fb289821d0d26fba4d7a0b7821dd49d420eade9c872"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f9f70b75f2cb7a0e3ab8fc134b8cc4cf791749e5d34d514f6271875f821e93a9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b08ed01c567884c35fb3950bc82261f3fd968c372e5c63bf9136b1a928ef70e0"
+  end
+
+  uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "openssl@3"
+  end
+end

--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -1,0 +1,32 @@
+class Gettext < Formula
+  desc "GNU internationalization (i18n) and localization (l10n) library"
+  homepage "https://www.gnu.org/software/gettext/"
+  url "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
+  sha256 "39acf4b0371e9b110b60005562aace5b3631fed9b1bb9ecccfc7f56e58bb1d7f"
+  license all_of: [
+    "GPL-3.0-or-later",
+    "LGPL-2.1-or-later", # libintl, libasprintf
+  ]
+
+  bottle do
+    sha256 arm64_tahoe:   "f1a3876bef27aa262949baa369395e4b9312845f79b86860124773ec6eef8608"
+    sha256 arm64_sequoia: "b25ac1e62443f8f79eadc3dadf6d3af954d4cbc33a0577fc626aa0c8f2bb01a5"
+    sha256 arm64_sonoma:  "1615e931a23c6875c9bcae0ffccf5a4a35f796fb90b7192804c771cb25d766e2"
+    sha256 arm64_ventura: "c9cf89dc04f56eb4939b00eea3c0361cd4498f8237e527f2f741682bf7e6de61"
+    sha256 sonoma:        "87ac92958d68cfd4c000879302cc8237f9ab38aec9429c6970b31667c3d53870"
+    sha256 ventura:       "36da5ebc7064150238eb5fd4c9640ee9ef2482cabb9707357d0ab7b198bf9c4f"
+    sha256 arm64_linux:   "65da5d3da37d8ac70048648ec6c0680d5c22f9f55b4452a61374c8c267d1990f"
+    sha256 x86_64_linux:  "fce5e0fea8441a729599191161a94a03ce4328e5c7a276df4ec322ff5e92958f"
+  end
+
+  depends_on "libunistring"
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "acl"
+  end
+end

--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -1,0 +1,22 @@
+class Libunistring < Formula
+  desc "C string library for manipulating Unicode strings"
+  homepage "https://www.gnu.org/software/libunistring/"
+  url "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
+  sha256 "8ea8ccf86c09dd801c8cac19878e804e54f707cf69884371130d20bde68386b7"
+  license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]
+
+  bottle do
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "640e9f79172d25b6b74cdc9084d9bc5fdee2afd6e6412b732852d14807ceb645"
+    sha256 cellar: :any,                 arm64_sequoia: "0cc291557b61cc7d02936f50d8ee84eb109b5ee4ebc5070175b6eb78d2210d9f"
+    sha256 cellar: :any,                 arm64_sonoma:  "97bdae1108cd8f835cbebd34e29aad5079582c12b670aa55ca4513a68857aae7"
+    sha256 cellar: :any,                 arm64_ventura: "af27e48e970fd7f05e3aafe1f0aca3ae6ffce74cb193e8d85b0fec26c2860292"
+    sha256 cellar: :any,                 sonoma:        "464e4554828d664abca64dc50d62f99d100d72d54907c6bb8829ec4029e63656"
+    sha256 cellar: :any,                 ventura:       "25be9fa66a76ecbafe9812b4e30a45d0455a8031386fe1373416a97b90c7e75b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "199d018f82fa63ad011465e9bcbbfd66cf737b764fd66a3ca9002e9f7db1de84"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "411b23b4ca5b77f9e57d22aed7dd9dc9b465d9581c0d5db452f157b1333abdf9"
+  end
+end
+


### PR DESCRIPTION
homebrew dropped bottles for macOS 13, so readd them:

## Tap this repo

``` 
bash-3.2$ brew tap puppetlabs/puppet
==> Tapping puppetlabs/puppet
Cloning into '/usr/local/Homebrew/Library/Taps/puppetlabs/homebrew-puppet'...
remote: Enumerating objects: 2405, done.
remote: Counting objects: 100% (325/325), done.
remote: Compressing objects: 100% (160/160), done.
remote: Total 2405 (delta 180), reused 180 (delta 161), pack-reused 2080 (from 2)
Receiving objects: 100% (2405/2405), 1.43 MiB | 20.88 MiB/s, done.
Resolving deltas: 100% (1365/1365), done.
Tapped 13 casks and 5 formulae (47 files, 1.6MB).
```

## Switch to branch:

```
bash-3.2$ cd "$(brew --repo puppetlabs/puppet)"
bash-3.2$ git checkout gettext
branch 'gettext' set up to track 'origin/gettext'.
Switched to a new branch 'gettext'
```

## Install cmake
```
bash-3.2$ brew install puppetlabs/puppet/cmake
Warning: You are using macOS 13.
We (and Apple) do not provide support for this old version.
You may have better luck with MacPorts which supports older versions of macOS:
  https://www.macports.org

This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
You can report Tier 3 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> Fetching downloads for: cmake
✔︎ Bottle Manifest cmake (3.31.6)                                                                             Downloaded   15.4KB/ 15.4KB
✔︎ Bottle cmake (3.31.6)                                                                                      Downloaded   20.2MB/ 20.2MB
==> Installing cmake from puppetlabs/puppet
==> Pouring cmake--3.31.6.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/cmake/3.31.6: 3,788 files, 63.7MB
==> Running `brew cleanup cmake`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/cmake
```

## Install libunistring

```
bash-3.2$ time brew install puppetlabs/puppet/libunistring
Warning: You are using macOS 13.
We (and Apple) do not provide support for this old version.
You may have better luck with MacPorts which supports older versions of macOS:
  https://www.macports.org

This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
You can report Tier 3 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> Fetching downloads for: libunistring
✔︎ Bottle Manifest libunistring (1.3)                                                                         Downloaded    9.4KB/  9.4KB
✔︎ Bottle libunistring (1.3)                                                                                  Downloaded    1.9MB/  1.9MB
==> Installing libunistring from puppetlabs/puppet
==> Pouring libunistring--1.3.ventura.bottle.1.tar.gz
🍺  /usr/local/Cellar/libunistring/1.3: 59 files, 5.8MB
==> Running `brew cleanup libunistring`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).

real	0m2.861s
user	0m1.226s
sys	0m0.507s
```

## Install gettext

```
bash-3.2$ time brew install puppetlabs/puppet/gettext
Warning: You are using macOS 13.
We (and Apple) do not provide support for this old version.
You may have better luck with MacPorts which supports older versions of macOS:
  https://www.macports.org

This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
You can report Tier 3 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> Fetching downloads for: gettext
✔︎ Bottle Manifest gettext (0.26)                                                                             Downloaded   17.9KB/ 17.9KB
✔︎ Bottle gettext (0.26)                                                                                      Downloaded    9.6MB/  9.6MB
==> Installing gettext from puppetlabs/puppet
==> Pouring gettext--0.26.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/gettext/0.26: 2,428 files, 29MB
==> Running `brew cleanup gettext`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).

real	0m6.862s
user	0m2.198s
sys	0m1.873s
```