### PR TITLE
(PA-8831) Get `brew tap puppetlabs/puppet` working

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install ${{ matrix.cask }} cask on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-13', 'macos-14' ]
+        macos: [ 'macos-14' ]
         cask: [ 'pe-client-tools', 'pdk', 'puppet-agent', 'puppet-agent-7', 'puppet-agent-8', 'puppet-bolt', 'puppet-bolt@2' ]
     env:
       HOMEBREW_LOGS: ~/homebrew-logs
@@ -37,7 +37,7 @@ jobs:
     name: Install ${{ matrix.formula }} formula on ${{ matrix.macos }}
     strategy:
       matrix:
-        macos: [ 'macos-13' ]
+        macos: [ 'macos-14' ]
         formula: [ 'kubectl-ran' ]
     runs-on: ${{ matrix.macos }}
     steps:

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -26,7 +26,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: brew install --cask Casks/${{ matrix.cask }}.rb --force
+      - name: Link checkout as the puppetlabs/puppet tap
+        run: |
+          tap_dir="$(brew --repository)/Library/Taps/puppetlabs/homebrew-puppet"
+          mkdir -p "$(dirname "$tap_dir")"
+          rm -rf "$tap_dir"
+          ln -s "$GITHUB_WORKSPACE" "$tap_dir"
+      - run: brew install --cask puppetlabs/puppet/${{ matrix.cask }} --force
   install_formulae:
     name: Install ${{ matrix.formula }} formula on ${{ matrix.macos }}
     strategy:
@@ -39,4 +45,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: brew install Formula/${{ matrix.formula }}.rb
+      - name: Link checkout as the puppetlabs/puppet tap
+        run: |
+          tap_dir="$(brew --repository)/Library/Taps/puppetlabs/homebrew-puppet"
+          mkdir -p "$(dirname "$tap_dir")"
+          rm -rf "$tap_dir"
+          ln -s "$GITHUB_WORKSPACE" "$tap_dir"
+      - run: brew install puppetlabs/puppet/${{ matrix.formula }}

--- a/Casks/pdk.rb
+++ b/Casks/pdk.rb
@@ -32,7 +32,7 @@ cask 'pdk' do
     end
   end
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/#{arch}/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 

--- a/Casks/pdk@1.rb
+++ b/Casks/pdk@1.rb
@@ -22,7 +22,6 @@ cask 'pdk@1' do
     sha256 '5ee08d46b072b418f3256d0f47d2979255b69e1b5d3e5ba207be390b75eb6482'
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/pdk-#{version}-1.osx#{os_ver}.dmg"
   pkg "pdk-#{version}-1-installer.pkg"
 

--- a/Casks/pe-client-tools-2018.1.rb
+++ b/Casks/pe-client-tools-2018.1.rb
@@ -10,7 +10,6 @@ cask 'pe-client-tools-2018.1' do
     sha256 '327891491b80567b2af035de53422f81e010e727373f055f13626eb10c9c4553'
   end
 
-  depends_on macos: '>= :sierra'
   url "https://pm.puppet.com/pe-client-tools/2018.1.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 

--- a/Casks/pe-client-tools-2019.3.rb
+++ b/Casks/pe-client-tools-2019.3.rb
@@ -10,7 +10,6 @@ cask 'pe-client-tools-2019.3' do
     sha256 'bccf0c588dd7d5e9dab92716e8471214c381e60f4f9246ba605091b253fb59f5'
   end
 
-  depends_on macos: '>= :sierra'
   url "https://pm.puppet.com/pe-client-tools/2019.3.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 

--- a/Casks/pe-client-tools-2019.8.rb
+++ b/Casks/pe-client-tools-2019.8.rb
@@ -10,7 +10,6 @@ cask 'pe-client-tools-2019.8' do
     sha256 '3cb72c8ac071b46b8b60a40a2018b44346205b386a1ee07e2006cd66ce98e3cb'
   end
 
-  depends_on macos: '>= :mojave'
   url "https://pm.puppet.com/pe-client-tools/2019.8.6/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 

--- a/Casks/pe-client-tools.rb
+++ b/Casks/pe-client-tools.rb
@@ -10,7 +10,6 @@ cask 'pe-client-tools' do
     sha256 '212568a6af374e40537c7180ae28d2083dc4f1ef8bbf26654019b1033a52d06c'
   end
 
-  depends_on macos: '>= :mojave'
   url "https://pm.puppet.com/pe-client-tools/2021.1.0/#{version}/repos/apple/#{os_ver}/PC1/x86_64/pe-client-tools-#{version}-1.osx#{os_ver}.dmg"
   pkg "pe-client-tools-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-6.rb
+++ b/Casks/puppet-agent-6.rb
@@ -56,7 +56,6 @@ cask 'puppet-agent-6' do
     end
   end
 
-  depends_on macos: '>= :sierra'
   url "https://downloads.puppet.com/mac/puppet6/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-7.rb
+++ b/Casks/puppet-agent-7.rb
@@ -40,7 +40,7 @@ cask 'puppet-agent-7' do
     end
   end
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
   url "https://downloads.puppet.com/mac/puppet7/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent-8.rb
+++ b/Casks/puppet-agent-8.rb
@@ -40,7 +40,7 @@ cask 'puppet-agent-8' do
     end
   end
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
   url "https://downloads.puppet.com/mac/puppet8/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-agent.rb
+++ b/Casks/puppet-agent.rb
@@ -40,7 +40,7 @@ cask 'puppet-agent' do
     end
   end
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
   url "https://downloads.puppet.com/mac/puppet/#{os_ver}/#{arch}/puppet-agent-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-agent-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-bolt.rb
+++ b/Casks/puppet-bolt.rb
@@ -68,7 +68,6 @@ cask 'puppet-bolt' do
     end
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/#{arch}/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 

--- a/Casks/puppet-bolt@2.rb
+++ b/Casks/puppet-bolt@2.rb
@@ -22,7 +22,6 @@ cask 'puppet-bolt@2' do
     sha256 'd8c4cbd2c2d6c4a0d8cb58007de2a7520939c51cabe8845d6d96013062d7e466'
   end
 
-  depends_on macos: '>= :el_capitan'
   url "https://downloads.puppet.com/mac/puppet-tools/#{os_ver}/x86_64/puppet-bolt-#{version}-1.osx#{os_ver}.dmg"
   pkg "puppet-bolt-#{version}-1-installer.pkg"
 


### PR DESCRIPTION
## 1. CI: install casks via tap token instead of file path

The `install_casks` job fails on every PR:

```
Error: Homebrew requires casks to be in a tap, rejecting:
  Casks/pdk.rb
```

The workflow installed casks by **file path** (`brew install --cask Casks/<cask>.rb`). Newer Homebrew **disabled** installing a cask from a loose `.rb` path that isn't part of a tap. The workflow didn't change; the GitHub-hosted `macos-13`/`macos-14` runners bumped to a Homebrew version that enforces this. (Formulae still accept a path, so `install_formulae` is unaffected.)

Fix: symlink the PR checkout into `Library/Taps/puppetlabs/homebrew-puppet` so Homebrew treats it as the `puppetlabs/puppet` tap, then install by token (`puppetlabs/puppet/<cask>`).

## 2. Modernize deprecated `depends_on macos:` syntax

Homebrew dropped support for `el_capitan`/`sierra`/`mojave`  symbols, so those cause a hard-error

Homebrew deprecated `depends_on` string-comparison form (`>= :big_sur`). The more compact form `depends_on: :big_sur` means the same thing.

## 3. Drop macOS 13

The macos-13 (Ventura) runner image is being deprecated and retired by GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)